### PR TITLE
Parser for `MSAMETFL` MSA metadata files

### DIFF
--- a/msaexp/tests/test_utils.py
+++ b/msaexp/tests/test_utils.py
@@ -1,3 +1,4 @@
+from .. import utils
 
 def test_import():
     """
@@ -9,13 +10,20 @@ def test_import():
 
 def test_wavelength_grids():
     
-    import msaexp.utils
     import grizli.utils
     grizli.utils.set_warnings()
     
-    for gr in msaexp.utils.GRATING_LIMITS:
-        grid = msaexp.utils.get_standard_wavelength_grid(gr)
-        grid = msaexp.utils.get_standard_wavelength_grid(gr, log_step=True)
+    for gr in utils.GRATING_LIMITS:
+        grid = utils.get_standard_wavelength_grid(gr)
+        grid = utils.get_standard_wavelength_grid(gr, log_step=True)
         
-    grid = msaexp.utils.get_standard_wavelength_grid('prism', free_prism=False)
+    grid = utils.get_standard_wavelength_grid('prism', free_prism=False)
+
+
+def test_meta_parser():
+    
+    uri = 'https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/'
+    regs = utils.regions_from_metafile(uri+'jw02756001001_01_msa.fits',
+                                       as_string=True,
+                                       with_bars=True)
     

--- a/msaexp/utils.py
+++ b/msaexp/utils.py
@@ -249,7 +249,7 @@ def slit_trace_center(slit, with_source_ypos=True, index_offset=0.):
     return xd, yd, lam, rs, ds
     
 
-def get_slit_corners(slit):
+def get_slit_corners(slit, wave=None, verbose=False):
     """
     """
     from gwcs import wcstools
@@ -270,13 +270,191 @@ def get_slit_corners(slit):
     smi = np.nanmin(sy)
     sma = np.nanmax(sy)
     
+    if verbose:
+        print(f'yslit: {smi:.2f} {sma:.2f}')
+        
     slit_x = np.array([-0.5, 0.5, 0.5, -0.5])
     slit_y = np.array([smi, smi, sma, sma])
     
-    ra_corner, dec_corner, _w = s2w(slit_x, slit_y, np.nanmedian(slam))
-    return ra_corner, dec_corner
+    if wave is None:
+        wave = np.nanmedian(slam)
+        
+    ra_corner, dec_corner, _w = s2w(slit_x, slit_y, wave)
     
+    return np.array([ra_corner, dec_corner])
     
+
+def regions_from_metafile(metafile, **kwargs):
+    """
+    """
+    metf = MSAMetafile(metafile)
+    regions = metf.regions_from_metafile(**kwargs)
+    return regions
+
+
+class MSAMetafile():
+    def __init__(self, metafile):
+        """
+        Helper for parsing MSAMETFL metadata files
+        """
+        import grizli.utils
+
+        self.metafile = metafile
+        
+        with pyfits.open(metafile) as im:
+            src = grizli.utils.GTable(im['SOURCE_INFO'].data)
+            shut = grizli.utils.GTable(im['SHUTTER_INFO'].data)
+    
+        # Merge src and shutter tables
+        shut_ix, src_ix = [], []
+
+        for i, sid in enumerate(shut['source_id']):
+            if sid == 0:
+                continue
+            elif sid in src['source_id']:
+                shut_ix.append(i)
+                src_ix.append(np.where(src['source_id'] == sid)[0][0])
+
+        for c in ['ra','dec','program']:
+            shut[c] = src[c][0]*0
+            shut[c][shut_ix] = src[c][src_ix]
+        
+        self.shutter_table = shut
+        self.src_table = src
+
+
+    def regions_from_metafile(self, dither_point_index=None, msa_metadata_id=None, fit_degree=2, as_string=False, with_bars=True, **kwargs):
+        """
+        Get slit footprints in sky coords
+        """
+        from astropy.modeling.models import Polynomial2D
+        from astropy.modeling.fitting import LinearLSQFitter
+        import grizli.utils
+
+        p2 = Polynomial2D(degree=fit_degree)
+        fitter = LinearLSQFitter()
+            
+        if dither_point_index is None:
+            dither_point_index = self.shutter_table['dither_point_index'].min()
+        if msa_metadata_id is None:
+            msa_metadata_id = self.shutter_table['msa_metadata_id'].min()
+    
+        dith = (self.shutter_table['dither_point_index'] == dither_point_index) 
+        metid = (self.shutter_table['msa_metadata_id'] == msa_metadata_id)
+        exp = dith & metid
+    
+        has_offset = np.isfinite(self.shutter_table['estimated_source_in_shutter_x'])
+        has_offset &= np.isfinite(self.shutter_table['estimated_source_in_shutter_y'])
+    
+        is_src = (self.shutter_table['source_id'] > 0) & (has_offset)
+        si = self.shutter_table[exp & is_src]
+    
+        # Fit for transformations
+        coeffs = {}
+        inv_coeffs = {}
+
+        for qi in np.unique(si['shutter_quadrant']):
+            q = si['shutter_quadrant'] == qi
+            # print(qi, q.sum())
+        
+            row = si['shutter_row'] + si['estimated_source_in_shutter_x']
+            col = si['shutter_column'] + si['estimated_source_in_shutter_y']
+
+            pra = fitter(p2, row[q], col[q], si['ra'][q])
+            pdec = fitter(p2, row[q], col[q], si['dec'][q])
+            coeffs[qi] = pra, pdec
+
+            prow = fitter(p2, si['ra'][q], si['dec'][q], row[q])
+            pcol = fitter(p2, si['ra'][q], si['dec'][q], col[q])
+            inv_coeffs[qi] = prow, pcol
+    
+        # Regions for a particular exposure
+        se = self.shutter_table[exp]
+    
+        sx = (np.array([-0.5, 0.5, 0.5, -0.5]))*(1-0.07/0.27*with_bars) + 0.5
+        sy = (np.array([-0.5, -0.5, 0.5, 0.5]))*(1-0.07/0.53*with_bars) + 0.5
+
+        row = se['shutter_row'] #+ se['estimated_source_in_shutter_x']
+        col = se['shutter_column'] #+ se['estimated_source_in_shutter_y']
+        ra, dec = se['ra'], se['dec']
+    
+        regions = []
+    
+        for i in range(len(se)):
+
+            pra, pdec = coeffs[se['shutter_quadrant'][i]]
+            sra = pra(row[i] + sx, col[i]+sy)
+            sdec = pdec(row[i] + sx, col[i]+sy)
+
+            sr = grizli.utils.SRegion(np.array([sra, sdec]), wrap=False)
+            sr.meta = {}
+            for k in ['program', 'source_id', 'ra', 'dec', 
+                      'slitlet_id', 'shutter_quadrant', 'shutter_row', 'shutter_column',
+                      'estimated_source_in_shutter_x', 'estimated_source_in_shutter_y']:
+                sr.meta[k] = se[k][i]
+        
+            sr.meta['is_source'] = np.isfinite(se['estimated_source_in_shutter_x'][i])
+        
+            if sr.meta['is_source']:
+                sr.ds9_properties = "color=green"
+            else:
+                sr.ds9_properties = "color=cyan"
+        
+            regions.append(sr)
+        
+        if as_string:
+            output = f'# msametfl = {self.metafile}\n'
+            output += f'# dither_point_index = {dither_point_index}\n'
+            output += f'# msa_metadata_id = {msa_metadata_id}\n'
+            
+            output += 'icrs\n'
+            for sr in regions:
+                m = sr.meta
+                if m['is_source']:
+                    output += f"circle({m['ra']:.7f}, {m['dec']:.7f}, 0.2\")"
+                    output += f" # color=white text=xx{m['source_id']}yy\n"
+                
+                for r in sr.region:
+                    output += r + '\n'
+            
+            output = output.replace('xx','{').replace('yy', '}')
+            
+        else:
+            output = regions
+            
+        return output
+    
+    #
+    # with open(regfile,'w') as fp:
+    #     fp.write('icrs\n')
+    #
+    #     row = se['shutter_row'] #+ se['estimated_source_in_shutter_x']
+    #     col = se['shutter_column'] #+ se['estimated_source_in_shutter_y']
+    #     ra, dec = se['ra'], se['dec']
+    #
+    #     for i in range(len(se)):
+    #
+    #         pra, pdec = coeffs[se['shutter_quadrant'][i]]
+    #         sra = pra(row[i] + sx, col[i]+sy)
+    #         sdec = pdec(row[i] + sx, col[i]+sy)
+    #
+    #         sr = utils.SRegion(np.array([sra, sdec]), wrap=False)
+    #         if se['source_id'][i] > 0:
+    #             circ = f'circle({ra[i]:.6f},{dec[i]:.6f},0.2")'
+    #             circ += ' # color=green'
+    #             circ += f" text=xx{se['source_id'][i]}yy".replace("xx","{").replace("yy","}")
+    #             fp.write(circ+'\n')
+    #             #sr.ds9_properties = f"color=magenta text=xx{se['source_id'][i]}yy".replace("xx","{").replace("yy","}")
+    #             sr.ds9_properties = "color=green"
+    #         else:
+    #             sr.ds9_properties = "color=cyan"
+    #
+    #
+    #
+    #         for r in sr.region:
+    #             fp.write(r+'\n')
+    
+
 GRATING_LIMITS = {'prism': [0.58, 5.33, 0.01], 
                   'g140m': [0.68, 1.9, 0.00063], 
                   'g235m': [1.66, 3.17, 0.00106], 


### PR DESCRIPTION
Class to read the metadata files and calculate regions for open slits on the mask.

```python
>>> meta = msaexp.utils.MSAMetafile('https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/jw02756001001_01_msa.fits')
>>> meta.regions_from_metafile(as_string=True, with_bars=True)
# msametfl = https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/jw02756001001_01_msa.fits
# dither_point_index = 1
# msa_metadata_id = 1
icrs
polygon(3.623046,-30.427251,3.622983,-30.427262,3.622951,-30.427136,3.623014,-30.427125) # color=cyan
circle(3.6229814, -30.4270337, 0.2") # color=white text={160159}
polygon(3.623009,-30.427106,3.622946,-30.427117,3.622915,-30.426991,3.622978,-30.426980) # color=green
polygon(3.622973,-30.426960,3.622910,-30.426971,3.622878,-30.426845,3.622941,-30.426834) # color=cyan
polygon(3.613902,-30.392060,3.613840,-30.392071,3.613809,-30.391948,3.613871,-30.391936) # color=cyan
circle(3.6137989, -30.3918859, 0.2") # color=white text={160321}
polygon(3.613867,-30.391918,3.613804,-30.391929,3.613774,-30.391805,3.613836,-30.391794) # color=green
polygon(3.613831,-30.391775,3.613769,-30.391786,3.613738,-30.391663,3.613800,-30.391652) # color=cyan
polygon(3.610960,-30.384123,3.610897,-30.384134,3.610867,-30.384011,3.610929,-30.384000) # color=cyan
...
```