### PR TITLE
Refactor 2D spectrum drizzling

### DIFF
--- a/msaexp/drizzle.py
+++ b/msaexp/drizzle.py
@@ -677,13 +677,8 @@ def make_optimal_extraction(waves, sci2d, wht2d, profile_slice=None,
                 profile_slice = slice(*profile_slice)
             else:
                 # Wavelengths interpolated on pixel grid
-                sh = drizzled_slits[0].data.shape
                 xpix = np.arange(sh[1])
-                ypix = np.zeros(sh[1]) + sh[0]/2
-    
-                _wcs = drizzled_slits[0].meta.wcs
-                _, _, wave0 = _wcs.forward_transform(xpix, ypix)
-                xsl = np.cast[int](np.round(np.interp(profile_slice, wave0, xpix)))
+                xsl = np.cast[int](np.round(np.interp(profile_slice, waves, xpix)))
                 xsl = np.clip(xsl, 0, sh[1])
                 print(f'Wavelength slice: {profile_slice} > {xsl} pix')
                 profile_slice = slice(*xsl)
@@ -707,7 +702,7 @@ def make_optimal_extraction(waves, sci2d, wht2d, profile_slice=None,
     y0 = yp - ytrace
         
     if prf_center is None:
-        prf_center = np.nanargmax(prof1d*msk) - (sh[0]-1)/2.
+        prf_center = np.nanargmax(prof1d) - (sh[0]-1)/2.
         if verbose:
             print(f'Set prf_center: {prf_center} {sh} {ok.sum()}')
     

--- a/msaexp/drizzle.py
+++ b/msaexp/drizzle.py
@@ -1,0 +1,573 @@
+"""
+Tools for drizzle-combining MSA spectra
+"""
+import glob
+import numpy as np
+import matplotlib.pyplot as plt
+from tqdm import tqdm
+import scipy.ndimage as nd
+
+import jwst.datamodels
+import astropy.io.fits as pyfits
+
+import grizli.utils
+
+from . import utils
+
+class DummyBackground(object):
+    def __init__(self, level=0.0):
+        self.level = level
+        self.subtracted = False
+
+
+DRIZZLE_PARAMS = dict(output=None,
+                      single=True,
+                      blendheaders=True,
+                      pixfrac=1.0,
+                      kernel='square',
+                      fillval=0,
+                      wht_type='ivm',
+                      good_bits=0,
+                      pscale_ratio=1.0,
+                      pscale=None)
+
+
+def metadata_tuple(slit):
+    """
+    Tuple of (msa_metadata_file, msa_metadata_id)
+    """
+    return slit.meta.instrument.msa_metadata_file, slit.meta.instrument.msa_metadata_id
+
+
+def center_wcs(slit, waves, center_on_source=False, force_nypix=31, fix_slope=None, slit_center=0.):
+    """
+    """
+    # Centered on source
+    wcs_data = utils.build_slit_centered_wcs(slit, waves,
+                                             force_nypix=force_nypix,
+                                             center_on_source=True,
+                                             get_from_ypos=False,
+                                             phase=0.,
+                                             fix_slope=fix_slope,
+                                             slit_center=slit_center)
+
+    slit.drizzle_slit_offset_source = slit.drizzle_slit_offset
+    
+    # Centered on slitlet
+    if center_on_source:
+        offset_to_source = 0.0
+    else:
+        wcs_data = utils.build_slit_centered_wcs(slit, waves,
+                                                    force_nypix=force_nypix,
+                                                    center_on_source=False,
+                                                    get_from_ypos=False,
+                                                    phase=0.,
+                                                    fix_slope=fix_slope,
+                                                    slit_center=slit_center)
+    
+        # Derived offset between source and center of slitlet
+        if slit_center != 0:
+            offset_to_source = 0.
+        else:
+            offset_to_source = slit.drizzle_slit_offset_source - slit.drizzle_slit_offset
+        
+        
+    #meta = slit.meta.instrument.msa_metadata_file
+
+    return wcs_data, offset_to_source, metadata_tuple(slit)
+
+
+def drizzle_slitlets(id, pipeline_extension='phot', root='msadriz', files=None, verbose=True, master_bkg=None, log_step=True, force_nypix=31, outlier_threshold=5, bkg_offset=5, bkg_parity=[1,-1], imshow_kws=dict(vmin=-0.1, vmax=0.5, aspect='auto', cmap='cubehelix_r'), mask_padded=False, center_on_source=False, fix_slope=None, make_figure=True, stuck_slit_test={'prism':(97.5, 7)}, **kwargs):
+    """
+    Implementing more direct drizzling of multiple 2D cutouts
+    
+    stuck_slit_test : dict
+        Test for stuck slits.  The keys are the grating names and the values are tuples of 
+         (``percentile``, ``threshold``).  If the S/N ``percentile`` is less than ``threshold``
+        then the slit is interpreted to be stuck closed.  The background in the prism spectra
+        should (almost?) always produce S/N > 10 pixels.
+    
+    """
+    from gwcs import wcstools
+    
+    if files is None:
+        files = glob.glob(f'*{pipeline_extension}*_{id}.fits')
+        #files = glob.glob(f'*{pipeline_extension}*_{id}.fits')
+        files.sort()
+        
+    ### Read the SlitModels
+    gratings = {}
+    for file in tqdm(files):
+        slit = jwst.datamodels.SlitModel(file)
+        grating = slit.meta.instance['instrument']['grating'].lower()
+        if grating not in gratings:
+            gratings[grating] = []
+    
+        gratings[grating].append(slit)
+    
+    if verbose:
+        for g in gratings:
+            print(g, len(gratings[g]))
+    
+    ### DQ mask
+    for gr in gratings:
+        slits = gratings[gr]
+        for i in range(len(slits)): #[18:40]:
+
+            slit = slits[i]
+
+            # msk = ~np.isfinite(slit.data)
+            # msk = nd.binary_dilation(msk, iterations=3)
+            # if 0:
+            #     #slit.data[msk] = np.nan
+            #     slit.dq[msk] |= 4
+            
+            if mask_padded:
+                print(f'Mask padded area of slitlets: {mask_padded*1:.1f}')
+                _wcs = slit.meta.wcs
+                d2s = _wcs.get_transform('detector', 'slit_frame')
+
+                bbox = _wcs.bounding_box
+                grid = wcstools.grid_from_bounding_box(bbox)
+                _, sy, slam = np.array(d2s(*grid))
+                msk = sy < np.nanmin(sy+mask_padded)
+                msk |= sy > np.nanmax(sy-mask_padded)
+                slit.data[msk] = np.nan
+                
+            slit.dq &= 1025
+            
+    #### Loop through gratings
+    figs = {}
+    data = {}
+    wavedata = {}
+    
+    for gr in gratings:
+        slits = gratings[gr]
+        
+        # ### Dummy background object
+        # for slit in slits:
+        #     slit.meta.background = DummyBackground()
+        #     slit.dq &= 1025
+        
+        ## Default wavelengths
+        waves = utils.get_standard_wavelength_grid(grating, sample=1, log_step=log_step)
+        
+        ## Drizzle 2D spectra
+        drz = None
+        drz_ids = []
+
+        force_yoffset = None
+        wcs_data = None
+        
+        # Approximate for default
+        to_ujy = 1.e12*5.e-13
+        
+        wcs_meta = None
+        
+        # Get offset from one science slit
+        for i in range(len(slits)): #[18:40]:
+            slit = slits[i]
+            if 'background' in slit.source_name:
+                continue
+            
+            wcs_data, offset_to_source, wcs_meta = center_wcs(slit,
+                                                          waves,
+                                                          force_nypix=force_nypix,
+                                                          center_on_source=center_on_source,
+                                                          fix_slope=fix_slope)
+            
+            to_ujy = 1.e12*slit.meta.photometry.pixelarea_steradians                                              
+            break
+        
+        if wcs_meta is None:
+            # Run for background slit
+            wcs_data, offset_to_source, wcs_meta = center_wcs(slits[0],
+                                                          waves,
+                                                          force_nypix=force_nypix,
+                                                          center_on_source=False,
+                                                          fix_slope=fix_slope,
+                                                          slit_center=1.0)
+            
+        # Now do the drizzling
+        exptime = 0.
+        
+        # FITS header metadata
+        h = pyfits.Header()
+        h['BKGOFF'] = bkg_offset, 'Background offset'
+        h['OTHRESH'] = outlier_threshold, 'Outlier mask threshold, sigma'
+        h['LOGWAVE'] = log_step, 'Target wavelengths are log spaced'
+        
+        h['BUNIT'] = 'mJy'
+        
+        inst = slit.meta.instance['instrument']
+        for k in ['grating','filter']:
+            h[k] = inst[k]
+        
+        h['NFILES'] = len(slits), 'Number of extracted slitlets'
+        h['EFFEXPTM'] = 0., 'Total effective exposure time'
+        
+        for slit in slits:
+            h[f'SRCNAME'] = slit.source_name, 'source_name from MSA file'
+            h[f'SRCID'] = slit.source_id, 'source_id from MSA file'
+            h[f'SRCRA'] = slit.source_ra, 'source_ra from MSA file'
+            h[f'SRCDEC'] = slit.source_dec, 'source_dec from MSA file'
+            
+            if slit.source_ra > 0:
+                break
+        
+        to_ujy_list = []
+        
+        for i in range(len(slits)): #[18:40]:
+            if verbose:
+                print(f'{gr} {i:2} {slit.source_name:18} {slit.source_id:9} '
+                      f'{slit.source_ypos:.3f} {files[i]} {slit.data.shape}')
+    
+            slit = slits[i]
+            drz_ids.append(slit.source_name)
+            
+            h['EFFEXPTM'] += slit.meta.exposure.effective_exposure_time
+            
+            if (metadata_tuple(slit) != wcs_meta) & center_on_source:
+                
+                wcs_data, offset_to_source, wcs_meta = center_wcs(slit,
+                                                              waves,
+                                                              force_nypix=force_nypix,
+                                                              center_on_source=center_on_source,
+                                                              fix_slope=fix_slope)
+                
+                print(f'Recenter on source ({metadata_tuple(slit)}) y={offset_to_source:.2f}')
+                
+                # Recalculate photometry scaling
+                to_ujy = 1.e12*slit.meta.photometry.pixelarea_steradians
+                            
+            h[f'SRCNAM{i}'] = slit.source_name, 'source_name from MSA file'
+            h[f'SRCID{i}'] = slit.source_id, 'source_id from MSA file'
+            h[f'SRCRA{i}'] = slit.source_ra, 'source_ra from MSA file'
+            h[f'SRCDEC{i}'] = slit.source_dec, 'source_dec from MSA file'
+            h[f'SLITID{i}'] = slit.slitlet_id, 'slitlet_id from MSA file'
+            h[f'FILE{i}'] = slit.meta.instance['filename']                
+            h[f'TOUJY{i}'] = to_ujy, 'Conversion to uJy/pix'
+            h[f'PIXAR{i}'] = (slit.meta.photometry.pixelarea_steradians,
+                             'pixelarea_steradians')
+                        
+            _waves, _header, _drz = utils.drizzle_slits_2d([slit], build_data=wcs_data,
+                                                              drizzle_params=DRIZZLE_PARAMS)
+            
+            to_ujy_list.append(to_ujy)
+            
+            if drz is None:
+                drz = _drz
+            else:
+                drz.extend(_drz)
+            
+            # if verbose:
+            #     fig, ax = plt.subplots(1,1,figsize=(8,3))
+            #     ax.imshow(_drz[0].data, vmin=-0.2, vmax=2, aspect='auto')
+            #     ax.set_ylabel(f'{i} {slit.source_id}')
+    
+        drz_ids = np.array(drz_ids)
+        
+        ## Are slitlets tagged as background?
+        is_bkg = np.array([d.startswith('background') for d in drz_ids])
+        is_bkg &= False # ignore, combine them all
+        
+        ############ Combined drizzled spectra
+        
+        ## First pass
+        sci = np.array([d.data*to_ujy_list[i]
+                        for i, d in enumerate(drz)])
+        err = np.array([d.err*to_ujy_list[i]
+                        for i, d in enumerate(drz)])
+        scim = np.array([d.data*to_ujy_list[i]
+                         for i, d in enumerate(drz)])
+        
+        stuck_slits = []
+        if gr in stuck_slit_test:
+            _test = stuck_slit_test[gr]
+            for i, d in enumerate(drz):
+                ok = np.isfinite(d.err + d.data) & (d.dq & 1025 == 0) & (d.err > 0)
+                sn = (d.data/d.err)[ok]
+                slit_sn = np.percentile(sn, _test[0])
+                if slit_sn < _test[1]:
+                    h[f'STUCK{i}'] = True, f'Slit is stuck closed ({slit_sn:.2f})'
+                    if verbose:
+                        slit_file = slits[i].meta.instance['filename'] 
+                        print(f'Slit {slit_file} appears to be stuck closed:'
+                              f' {_test[0]:.1f} S/N = {slit_sn:.2f} < {_test[1]:.1f}')
+                               
+                    stuck_slits.append(i)
+        
+        for i in stuck_slits:
+            sci[i] *= np.nan
+            err[i] *= np.nan
+            scim[i] *= np.nan
+        
+        scima = np.nanmax(sci, axis=0)
+        scim[(scim >= scima)] = np.nan
+        
+        ivar = 1./err**2
+        ivar[err <= 0] = 0
+        ivarm = ivar*1.
+        ivarm[~np.isfinite(scim)] = 0
+        ivar[~np.isfinite(sci)] = 0
+        ivarm[scim == 0] = 0
+        ivar[sci == 0] = 0
+
+        scim[ivarm == 0] = 0
+        sci[ivar == 0] = 0
+
+        sci[ivar == 0] = np.nan
+        avg = np.nanmedian(sci, axis=0)
+        avg_w = ivarm.sum(axis=0)
+
+        ## Second pass
+        sci = np.array([d.data*to_ujy_list[i]
+                        for i, d in enumerate(drz)])
+        err = np.array([d.err*to_ujy_list[i]
+                        for i, d in enumerate(drz)])
+        scim = np.array([d.data*to_ujy_list[i]
+                         for i, d in enumerate(drz)])
+        
+        for i in stuck_slits:
+            sci[i] *= np.nan
+            err[i] *= np.nan
+            scim[i] *= np.nan
+        
+        scima = np.nanmax(sci, axis=0)
+        scim[((sci - avg)/err > outlier_threshold)] = np.nan
+        
+        ivar = 1./err**2
+        ivar[err <= 0] = 0
+        ivarm = ivar*1.
+        ivarm[~np.isfinite(scim)] = 0
+        ivar[~np.isfinite(sci)] = 0
+        ivarm[scim == 0] = 0
+        ivar[sci == 0] = 0
+
+        scim[ivarm == 0] = 0
+        sci[ivar == 0] = 0
+        
+        # Weighted combination of unmasked pixels
+        avg = (scim*ivarm)[~is_bkg,:].sum(axis=0)/ivarm[~is_bkg,:].sum(axis=0)
+        avg_w = ivarm[~is_bkg,:].sum(axis=0)
+        
+        # Set masked pixels to zero
+        msk = ~np.isfinite(avg + avg_w)
+        avg[msk] = 0
+        avg_w[msk] = 0
+        
+        # Background by rolling average array
+        bkg_num = avg*0.
+        bkg_w = avg*0
+        for s in bkg_parity:
+            bkg_num += np.roll(avg*avg_w, s*bkg_offset, axis=0)
+            bkg_w += np.roll(avg_w, s*bkg_offset, axis=0)
+
+        bkg_w[:bkg_offset] = 0
+        bkg_w[-bkg_offset:] = 0
+        
+        # Set masked back to nan
+        avg[msk] = np.nan
+        avg_w[msk] = np.nan
+
+        bkg = bkg_num/bkg_w
+        
+        # Use master background if supplied
+        if master_bkg is not None:
+            bkg = master_bkg[0]
+            bkg_w = master_bkg[1]
+        
+        # Trace center
+        to_source = (avg.shape[0]-1)//2 + offset_to_source
+        x0 = np.cast[int](np.round(to_source))
+        
+        h['SRCYPIX'] = to_source, 'Expected row of source centering'
+        
+        # Valid data along wavelength axis
+        xvalid = np.isfinite(avg).sum(axis=0) > 0
+        xvalid &= nd.binary_erosion(nd.binary_dilation(xvalid, iterations=2), iterations=4)
+        
+        # Make a figure
+        if make_figure:
+            
+            fig, axes = plt.subplots(3,1, figsize=(14,8), sharex=True, sharey=True)
+            axes[0].imshow(avg, **imshow_kws)
+            axes[1].imshow(avg-bkg, **imshow_kws)
+            axes[2].imshow(bkg, **imshow_kws)
+            xr = np.arange(avg.shape[1])[xvalid]
+            axes[0].set_ylabel('Data')
+            axes[1].set_ylabel('Cleaned')
+            axes[2].set_ylabel('Background')
+        
+            for ax in axes:
+                ax.set_yticks([0,x0-bkg_offset, x0,x0+bkg_offset, avg.shape[0]])
+                ax.set_yticklabels([0, -bkg_offset, x0, bkg_offset, avg.shape[0]])
+    
+                ax.grid()
+                ax.set_xlim(xr[0]-5, xr[-1]+5)
+                ax.set_ylim(x0-2*bkg_offset, x0+2*bkg_offset)
+        
+            ax.set_xlabel('pixel')
+            axes[0].set_title(f"{h['SRCNAME']} {gr}")
+            fig.tight_layout(pad=1)
+            
+        else:
+            fig = None
+        
+        
+        # Build HDUList
+        h['EXTNAME'] = 'SCI'
+        hdul = pyfits.HDUList([pyfits.ImageHDU(data=avg, header=h)])
+        h['EXTNAME'] = 'WHT'
+        hdul.append(pyfits.ImageHDU(data=avg_w, header=h))
+        h['EXTNAME'] = 'BKG'
+        hdul.append(pyfits.ImageHDU(data=bkg, header=h))
+        
+        # Add to data dicts
+        figs[gr] = fig
+        data[gr] = hdul
+        wavedata[gr] = waves
+        
+    return figs, data, wavedata
+
+
+def fit_profile(waves, sci2d, wht2d, profile_slice=None, prf_center=None, prf_sigma=1.0, sigma_bounds=(0.5, 2.0), fit_prf=True, fix_center=False, center_limit=4, trim=0, fix_sigma=False, verbose=True):
+    """
+    """
+    from photutils.psf import IntegratedGaussianPRF
+    from astropy.modeling.models import Polynomial2D, Gaussian1D
+    from astropy.modeling.fitting import LevMarLSQFitter
+    import scipy.ndimage as nd
+    import astropy.units as u
+    
+    sh = wht2d.shape
+    yp, xp = np.indices(sh)
+    
+    if profile_slice is not None:
+        prof1d = np.nansum((sci2d * wht2d)[:,profile_slice], axis=1) 
+        prof1d /= np.nansum(wht2d[:,profile_slice], axis=1)
+        slice_limits = profile_slice.start, profile_slice.stop
+    else:
+        prof1d = np.nansum(sci2d * wht2d, axis=1) / np.nansum(wht2d, axis=1)
+        slice_limits = 0, sh[1]
+    
+    ok = np.isfinite(prof1d)
+    # Trim edges
+    ok[np.where(ok)[0][:1]] = False
+    ok[np.where(ok)[0][-1:]] = False
+    
+    ok &= (prof1d > 0)
+    
+    xpix = np.arange(sh[0])
+    # ytrace = np.nanmedian(ytr)
+    # print('xxx', ytrace, sh[0]/2)
+    ytrace = sh[0]/2.
+    x0 = np.arange(sh[0]) - ytrace
+    y0 = yp - ytrace
+    
+    if prf_center is None:
+        msk = ok & (np.abs(x0) < center_limit)
+        prf_center = np.nanargmax(prof1d*msk) - sh[0]/2.
+        if verbose:
+            print(f'Set prf_center: {prf_center} {sh} {ok.sum()}')
+        
+    ok &= np.abs(x0 - prf_center) < center_limit
+    
+    prf = IntegratedGaussianPRF(x_0=0, y_0=prf_center, sigma=prf_sigma)
+    gau = Gaussian1D(mean=prf_center, stddev=prf_sigma)
+    
+    if (fit_prf > 0) & (ok.sum() > (2 - fix_center - fix_sigma)):
+        fitter = LevMarLSQFitter()
+        
+        if fit_prf == 2:
+            gau.bounds['stddev'] = sigma_bounds
+            gfit = fitter(gau, x0[ok], prof1d[ok])
+            prf.y_0 = gfit.mean
+            prf.sigma = gfit.stddev
+            sigma_bounds = [0.8, 1.5*gfit.stddev]
+            prf_center = gfit.mean
+            # print(gfit)
+            
+        prf.fixed['x_0'] = True
+        prf.fixed['y_0'] = fix_center
+        prf.fixed['sigma'] = fix_sigma    
+        prf.bounds['sigma'] = sigma_bounds
+        prf.bounds['y_0'] = (prf_center-center_limit, prf_center+center_limit)
+        
+        
+        pfit = fitter(prf, x0[ok]*0., x0[ok], prof1d[ok])
+        
+        if verbose:
+            msg = f'fit_prf: center = {pfit.y_0.value:.2f}'
+            msg += f'. sigma = {pfit.sigma.value:.2f}'
+            print(msg)
+        
+    else:
+        pfit = prf
+    
+    #plt.plot(x0, prof1d)
+    #plt.plot(x0, pfit(x0*0, x0))
+
+    # Renormalize for 1D
+    pfit.flux = prf.sigma.value*np.sqrt(2*np.pi)
+    
+
+    profile2d = pfit(y0*0., y0)
+    wht1d = np.nansum(wht2d*profile2d**2, axis=0)
+    sci1d = np.nansum(sci2d*wht2d*profile2d, axis=0) / wht1d
+    
+    if profile_slice is not None:
+        pfit1d = np.nansum((wht2d*profile2d*sci1d)[:,profile_slice], axis=1) 
+        pfit1d /= np.nansum(wht2d[:,profile_slice], axis=1)
+    else:
+        pfit1d = np.nansum(profile2d*sci1d * wht2d, axis=1) / np.nansum(wht2d, axis=1)
+    
+    if trim > 0:
+        bad = nd.binary_dilation(wht1d <= 0, iterations=trim)
+        wht1d[bad] = 0
+        
+    sci1d[wht1d <= 0] = 0
+    err1d = np.sqrt(1/wht1d)
+    err1d[wht1d <= 0] = 0
+    
+    #plt.imshow(profile2d)
+    #plt.plot(sci1d)
+    
+    ####### Make tables
+    # Flux conversion
+    to_ujy = 1. # Already applied in drizzle_slitlets
+    # to_ujy = 1.e12*5.e-13 #drizzled_slits[0].meta.photometry.pixelarea_steradians
+    
+    spec = grizli.utils.GTable()
+    spec.meta['VERSION'] = msaexp.__version__, 'msaexp software version'
+        
+    # spec.meta['TOMUJY'] = to_ujy, 'Conversion from pixel values to microJansky'
+    spec.meta['PROFCEN'] = pfit.y_0.value, 'PRF profile center'
+    spec.meta['PROFSIG'] = pfit.sigma.value, 'PRF profile sigma'
+    spec.meta['PROFSTRT'] = slice_limits[0], 'Start of profile slice'
+    spec.meta['PROFSTOP'] = slice_limits[1], 'End of profile slice'
+    spec.meta['YTRACE'] = ytrace, 'Expected center of trace'
+    
+    prof_tab = grizli.utils.GTable()
+    prof_tab.meta['VERSION'] = msaexp.__version__, 'msaexp software version'
+    prof_tab['pix'] = x0
+    prof_tab['profile'] = prof1d
+    prof_tab['pfit'] = pfit1d
+    prof_tab.meta['PROFCEN'] = pfit.y_0.value, 'PRF profile center'
+    prof_tab.meta['PROFSIG'] = pfit.sigma.value, 'PRF profile sigma'
+    prof_tab.meta['PROFSTRT'] = slice_limits[0], 'Start of profile slice'
+    prof_tab.meta['PROFSTOP'] = slice_limits[1], 'End of profile slice'
+    prof_tab.meta['YTRACE'] = ytrace, 'Expected center of trace'
+        
+    spec['wave'] = waves
+    spec['wave'].unit = u.micron
+    spec['flux'] = sci1d*to_ujy
+    spec['err'] = err1d*to_ujy
+    spec['flux'].unit = u.microJansky
+    spec['err'].unit = u.microJansky
+    
+    msk = np.isfinite(sci2d + wht2d)
+    sci2d[~msk] = 0
+    wht2d[~msk] = 0
+    
+    return sci2d, wht2d, profile2d, spec, prof_tab    

--- a/msaexp/drizzle.py
+++ b/msaexp/drizzle.py
@@ -2,9 +2,11 @@
 Tools for drizzle-combining MSA spectra
 """
 import glob
+import warnings
+from tqdm import tqdm
+
 import numpy as np
 import matplotlib.pyplot as plt
-from tqdm import tqdm
 import scipy.ndimage as nd
 
 import jwst.datamodels
@@ -14,12 +16,7 @@ import grizli.utils
 
 from . import utils
 
-class DummyBackground(object):
-    def __init__(self, level=0.0):
-        self.level = level
-        self.subtracted = False
-
-
+# Parameter defaults
 DRIZZLE_PARAMS = dict(output=None,
                       single=True,
                       blendheaders=True,
@@ -31,23 +28,79 @@ DRIZZLE_PARAMS = dict(output=None,
                       pscale_ratio=1.0,
                       pscale=None)
 
+FIGSIZE = (10,4)
+IMSHOW_KWS = dict(vmin=-0.1,
+                  vmax=None,
+                  aspect='auto',
+                  interpolation='nearest',
+                  origin='lower',
+                  cmap='cubehelix_r')
+
 
 def metadata_tuple(slit):
     """
     Tuple of (msa_metadata_file, msa_metadata_id)
+    
+    Parameters
+    ----------
+    slit : `jwst.datamodels.SlitModel`
+        Slitlet data object
+    
+    Returns
+    -------
+    meta : (str, str)
+        Tuple of `(msa_metadata_file, msa_metadata_id)`
+    
     """
     return slit.meta.instrument.msa_metadata_file, slit.meta.instrument.msa_metadata_id
 
 
-def center_wcs(slit, waves, center_on_source=False, force_nypix=31, fix_slope=None, slit_center=0.):
+def center_wcs(slit, waves, center_on_source=False, force_nypix=31, fix_slope=None, slit_center=0., center_phase=-0.5):
     """
+    Derive a 2D spectral WCS centered on the expected source position along the slit
+    
+    Parameters
+    ----------
+    slit : `jwst.datamodels.SlitModel`
+        Slitlet data object
+    
+    waves : array-like
+        Target wavelength array
+    
+    center_on_source : bool
+        Center on the source position along the slit.  If not, center on `slit_center`
+        slit coordinate
+    
+    force_nypix : int
+        Cross-dispersion size of the output 2D WCS
+    
+    fix_slope : float
+        Fixed cross-dispersion pixel size, in units of the slit coordinate frame
+    
+    slit_center : float
+        Define the center of the slit in the slit coordinate frame
+    
+    center_phase : float
+        Pixel phase defining the center of the slit alignment
+    
+    Returns
+    -------
+    wcs_data : object
+        Output from `msaexp.utils.build_slit_centered_wcs`
+    
+    offset_to_source : float
+        Offset between center of the WCS and the expected source position
+    
+    meta : tuple
+        MSA key from `msaexp.drizzle.metadata_tuple`
+    
     """
     # Centered on source
     wcs_data = utils.build_slit_centered_wcs(slit, waves,
                                              force_nypix=force_nypix,
                                              center_on_source=True,
                                              get_from_ypos=False,
-                                             phase=0.,
+                                             phase=center_phase,
                                              fix_slope=fix_slope,
                                              slit_center=slit_center)
 
@@ -61,53 +114,134 @@ def center_wcs(slit, waves, center_on_source=False, force_nypix=31, fix_slope=No
                                                     force_nypix=force_nypix,
                                                     center_on_source=False,
                                                     get_from_ypos=False,
-                                                    phase=0.,
+                                                    phase=center_phase,
                                                     fix_slope=fix_slope,
                                                     slit_center=slit_center)
     
         # Derived offset between source and center of slitlet
-        if slit_center != 0:
-            offset_to_source = 0.
-        else:
-            offset_to_source = slit.drizzle_slit_offset_source - slit.drizzle_slit_offset
-        
-        
-    #meta = slit.meta.instrument.msa_metadata_file
-
+        offset_to_source = slit.drizzle_slit_offset_source - slit.drizzle_slit_offset
+    
     return wcs_data, offset_to_source, metadata_tuple(slit)
 
 
-def drizzle_slitlets(id, pipeline_extension='phot', root='msadriz', files=None, verbose=True, master_bkg=None, log_step=True, force_nypix=31, outlier_threshold=5, bkg_offset=5, bkg_parity=[1,-1], imshow_kws=dict(vmin=-0.1, vmax=0.5, aspect='auto', cmap='cubehelix_r'), mask_padded=False, center_on_source=False, fix_slope=None, make_figure=True, stuck_slit_test={'prism':(97.5, 7)}, **kwargs):
+def drizzle_slitlets(id, wildcard='*phot', files=None, output=None, verbose=True, drizzle_params=DRIZZLE_PARAMS, master_bkg=None, waves=None, wave_sample=1, log_step=True, force_nypix=31, center_on_source=False, center_phase=-0.5, fix_slope=None, outlier_threshold=5, sn_threshold=3, bar_threshold=0.7, err_threshold=1000, bkg_offset=5, bkg_parity=[1,-1], mask_padded=False, show_drizzled=True, show_slits=True, imshow_kws=IMSHOW_KWS, **kwargs):
     """
-    Implementing more direct drizzling of multiple 2D cutouts
+    Implementing more direct drizzling of multiple 2D slitlets
     
-    stuck_slit_test : dict
-        Test for stuck slits.  The keys are the grating names and the values are tuples of 
-         (``percentile``, ``threshold``).  If the S/N ``percentile`` is less than ``threshold``
-        then the slit is interpreted to be stuck closed.  The background in the prism spectra
-        should (almost?) always produce S/N > 10 pixels.
+    Parameters
+    ----------
+    id, wildcard : object, str
+        Values to search for extracted slitlet files:
+    
+        .. code-block:: python
+            :dedent:
+            
+            files = glob.glob(f'{wildcard}*_{id}.fits')
+    
+    files : list
+        Explicit list of slitlet files
+    
+    output : str
+        Optional rootname of output figures and FITS data
+    
+    verbose : bool
+        Verbose messaging
+    
+    drizzle_params : dict
+        Drizzle parameters passed to `msaexp.utils.drizzle_slits_2d`
+    
+    master_bkg : array-like
+        Master background to replace local background derived from the drizzled product
+    
+    waves : array-like
+        Explicit arget wavelength array
+    
+    wave_sample, log_step : float, bool
+        If `waves` not specified, generate with `msaexp.utils.get_standard_wavelength_grid`
+    
+    force_nypix, center_on_source, center_phase, fix_slope : int, bool, float, float
+        Parameters of `msaexp.drizzle.center_wcs`
+    
+    outlier_threshold : int
+        Outlier threshold in drizzle combination
+    
+    sn_threshold : float
+        Mask pixels in slitlets where `data/err < sn_threshold`.  For the prism, essentially
+        all pixels should have S/N > 5 from the background, so this mask can help identify
+        and mask stuck-closed slitlets
+    
+    bar_threshold : float
+        Mask pixels in slitlets where `barshadow < bar_threshold`
+    
+    err_threshold : float
+        Mask pixels in slitlets where `err > err_threshold*median(err)`.  There are some
+        strange pixels with very large uncertainties in the pipeline products.
+    
+    bkg_offset, bkg_parity : int, list
+        Offset in pixels for defining the local background of the drizzled product, which is
+        derived by rolling the data array by `bkg_offset*bkg_parity` pixels.  The standard
+        three-shutter nod pattern corresponds to about 5 pixels.  An optimal combination seems
+        to be ``fix_slope=0.2``, ``bkg_offset=6``.
+    
+    mask_padded : bool
+        Mask pixels of slitlets that had been padded around the nominal MSA slitlets
+    
+    show_drizzled : bool
+        Make a figure with `msaexp.drizzle.show_drizzled_product` showing the drizzled combined
+        arrays.  If `output` specified, save to `{output}-{id}-[grating].d2d.png`.
+    
+    show_slits : bool
+        Make a figure with `msaexp.drizzle.show_drizzled_slits` showing the individual drizzled
+        slitlets.  If `output` specified, save to `{output}-{id}-[grating].slit2d.png`.
+    
+    imshow_kws : dict
+        Keyword arguments for ``matplotlib.pyplot.imshow`` in `show_drizzled` and `show_slits`
+        figures.
+    
+    Returns
+    -------
+    figs : dict
+        Any figures that were created, keys are separated by grating+filter here and below
+    
+    data : dict
+        `~astropy.io.fits.HDUList` FITS data for the drizzled output
+    
+    wavedata : dict
+        Wavelength arrays
+    
+    all_slits : dict
+        `SlitModel` objects for the input slitlets
+    
+    drz_data : dict
+        3D `sci` and `wht` arrays of the drizzled slitlets that were combined into the drizzled
+        stack
     
     """
     from gwcs import wcstools
     
     if files is None:
-        files = glob.glob(f'*{pipeline_extension}*_{id}.fits')
+        files = glob.glob(f'{wildcard}*_{id}.fits')
         #files = glob.glob(f'*{pipeline_extension}*_{id}.fits')
         files.sort()
         
     ### Read the SlitModels
     gratings = {}
-    for file in tqdm(files):
+    for file in files:
         slit = jwst.datamodels.SlitModel(file)
-        grating = slit.meta.instance['instrument']['grating'].lower()
-        if grating not in gratings:
-            gratings[grating] = []
+        grating = slit.meta.instrument.grating.lower()
+        filt = slit.meta.instrument.filter.lower()
+        key = f'{grating}-{filt}'
+        if key not in gratings:
+            gratings[key] = []
     
-        gratings[grating].append(slit)
+        gratings[key].append(slit)
     
     if verbose:
         for g in gratings:
-            print(g, len(gratings[g]))
+            msg = f'msaexp.drizzle.drizzle_slitlets: id={id}  {g} N={len(gratings[g])}'
+            grizli.utils.log_comment(grizli.utils.LOGFILE, msg, verbose=verbose, 
+                                     show_date=False)
+            
     
     ### DQ mask
     for gr in gratings:
@@ -116,14 +250,11 @@ def drizzle_slitlets(id, pipeline_extension='phot', root='msadriz', files=None, 
 
             slit = slits[i]
 
-            # msk = ~np.isfinite(slit.data)
-            # msk = nd.binary_dilation(msk, iterations=3)
-            # if 0:
-            #     #slit.data[msk] = np.nan
-            #     slit.dq[msk] |= 4
-            
             if mask_padded:
-                print(f'Mask padded area of slitlets: {mask_padded*1:.1f}')
+                msg = f'Mask padded area of slitlets: {mask_padded*1:.1f}'
+                grizli.utils.log_comment(grizli.utils.LOGFILE, msg, verbose=verbose, 
+                                         show_date=False)
+                
                 _wcs = slit.meta.wcs
                 d2s = _wcs.get_transform('detector', 'slit_frame')
 
@@ -133,24 +264,29 @@ def drizzle_slitlets(id, pipeline_extension='phot', root='msadriz', files=None, 
                 msk = sy < np.nanmin(sy+mask_padded)
                 msk |= sy > np.nanmax(sy-mask_padded)
                 slit.data[msk] = np.nan
+            
+            if hasattr(slit, 'barshadow'):
+                msk  = slit.barshadow < bar_threshold
+                slit.data[msk] = np.nan
                 
-            slit.dq &= 1025
+            slit.dq = (slit.dq & 1025 > 0)*1
+            slit.data[slit.dq > 0] = np.nan
             
     #### Loop through gratings
     figs = {}
     data = {}
     wavedata = {}
+    all_slits = {}
+    drz_data = {}
     
     for gr in gratings:
         slits = gratings[gr]
         
-        # ### Dummy background object
-        # for slit in slits:
-        #     slit.meta.background = DummyBackground()
-        #     slit.dq &= 1025
-        
         ## Default wavelengths
-        waves = utils.get_standard_wavelength_grid(grating, sample=1, log_step=log_step)
+        if waves is None:
+            waves = utils.get_standard_wavelength_grid(grating,
+                                                       sample=wave_sample,
+                                                       log_step=log_step)
         
         ## Drizzle 2D spectra
         drz = None
@@ -170,36 +306,43 @@ def drizzle_slitlets(id, pipeline_extension='phot', root='msadriz', files=None, 
             if 'background' in slit.source_name:
                 continue
             
-            wcs_data, offset_to_source, wcs_meta = center_wcs(slit,
-                                                          waves,
-                                                          force_nypix=force_nypix,
-                                                          center_on_source=center_on_source,
-                                                          fix_slope=fix_slope)
+            _center = center_wcs(slit,
+                                 waves,
+                                 force_nypix=force_nypix,
+                                 center_on_source=center_on_source,
+                                 fix_slope=fix_slope,
+                                 center_phase=center_phase)
             
-            to_ujy = 1.e12*slit.meta.photometry.pixelarea_steradians                                              
+            wcs_data, offset_to_source, wcs_meta = _center
+            to_ujy = 1.e12*slit.meta.photometry.pixelarea_steradians
             break
         
         if wcs_meta is None:
-            # Run for background slit
-            wcs_data, offset_to_source, wcs_meta = center_wcs(slits[0],
-                                                          waves,
-                                                          force_nypix=force_nypix,
-                                                          center_on_source=False,
-                                                          fix_slope=fix_slope,
-                                                          slit_center=1.0)
-            
+            # Run for background slits centered on slitlet if all skipped above
+            _center = center_wcs(slits[0],
+                                 waves,
+                                 force_nypix=force_nypix,
+                                 center_on_source=False,
+                                 fix_slope=fix_slope,
+                                 slit_center=1.0,
+                                 center_phase=center_phase)
+                                 
+            wcs_data, offset_to_source, wcs_meta = _center
+            to_ujy = 1.e12*slits[0].meta.photometry.pixelarea_steradians
+
+        ##################
         # Now do the drizzling
-        exptime = 0.
         
         # FITS header metadata
         h = pyfits.Header()
         h['BKGOFF'] = bkg_offset, 'Background offset'
         h['OTHRESH'] = outlier_threshold, 'Outlier mask threshold, sigma'
+        h['WSAMPLE'] = wave_sample, 'Wavelength sampling factor'
         h['LOGWAVE'] = log_step, 'Target wavelengths are log spaced'
         
         h['BUNIT'] = 'mJy'
         
-        inst = slit.meta.instance['instrument']
+        inst = slits[0].meta.instance['instrument']
         for k in ['grating','filter']:
             h[k] = inst[k]
         
@@ -218,40 +361,45 @@ def drizzle_slitlets(id, pipeline_extension='phot', root='msadriz', files=None, 
         to_ujy_list = []
         
         for i in range(len(slits)): #[18:40]:
-            if verbose:
-                print(f'{gr} {i:2} {slit.source_name:18} {slit.source_id:9} '
-                      f'{slit.source_ypos:.3f} {files[i]} {slit.data.shape}')
-    
             slit = slits[i]
+            
+            msg = f'msaexp.drizzle.drizzle_slitlets: '
+            msg += f'{gr} {i:2} {slit.source_name:18} {slit.source_id:9}'
+            msg += f' {slit.source_ypos:.3f} {files[i]} {slit.data.shape}'
+            grizli.utils.log_comment(grizli.utils.LOGFILE, msg, verbose=verbose, 
+                                     show_date=False)
+    
             drz_ids.append(slit.source_name)
             
             h['EFFEXPTM'] += slit.meta.exposure.effective_exposure_time
             
             if (metadata_tuple(slit) != wcs_meta) & center_on_source:
                 
-                wcs_data, offset_to_source, wcs_meta = center_wcs(slit,
-                                                              waves,
-                                                              force_nypix=force_nypix,
-                                                              center_on_source=center_on_source,
-                                                              fix_slope=fix_slope)
+                _center = center_wcs(slit,
+                                     waves,
+                                     force_nypix=force_nypix,
+                                     center_on_source=center_on_source,
+                                     fix_slope=fix_slope,
+                                     center_phase=center_phase,
+                                     )
                 
-                print(f'Recenter on source ({metadata_tuple(slit)}) y={offset_to_source:.2f}')
+                wcs_data, offset_to_source, wcs_meta = _center
+                
+                msg = f'msaexp.drizzle.drizzle_slitlets: '
+                msg += f'Recenter on source ({metadata_tuple(slit)}) y={offset_to_source:.2f}'
+                grizli.utils.log_comment(grizli.utils.LOGFILE, msg, verbose=verbose, 
+                                         show_date=False)
                 
                 # Recalculate photometry scaling
                 to_ujy = 1.e12*slit.meta.photometry.pixelarea_steradians
-                            
-            h[f'SRCNAM{i}'] = slit.source_name, 'source_name from MSA file'
-            h[f'SRCID{i}'] = slit.source_id, 'source_id from MSA file'
-            h[f'SRCRA{i}'] = slit.source_ra, 'source_ra from MSA file'
-            h[f'SRCDEC{i}'] = slit.source_dec, 'source_dec from MSA file'
-            h[f'SLITID{i}'] = slit.slitlet_id, 'slitlet_id from MSA file'
-            h[f'FILE{i}'] = slit.meta.instance['filename']                
-            h[f'TOUJY{i}'] = to_ujy, 'Conversion to uJy/pix'
-            h[f'PIXAR{i}'] = (slit.meta.photometry.pixelarea_steradians,
-                             'pixelarea_steradians')
-                        
-            _waves, _header, _drz = utils.drizzle_slits_2d([slit], build_data=wcs_data,
-                                                              drizzle_params=DRIZZLE_PARAMS)
+            
+            # Slit metadata
+            keys = utils.slit_metadata_to_header(slit, key=i+1, header=h)
+            
+            # Do the drizzling
+            _waves, _header, _drz = utils.drizzle_slits_2d([slit],
+                                                           build_data=wcs_data,
+                                                           drizzle_params=drizzle_params)
             
             to_ujy_list.append(to_ujy)
             
@@ -259,12 +407,7 @@ def drizzle_slitlets(id, pipeline_extension='phot', root='msadriz', files=None, 
                 drz = _drz
             else:
                 drz.extend(_drz)
-            
-            # if verbose:
-            #     fig, ax = plt.subplots(1,1,figsize=(8,3))
-            #     ax.imshow(_drz[0].data, vmin=-0.2, vmax=2, aspect='auto')
-            #     ax.set_ylabel(f'{i} {slit.source_id}')
-    
+        
         drz_ids = np.array(drz_ids)
         
         ## Are slitlets tagged as background?
@@ -273,90 +416,72 @@ def drizzle_slitlets(id, pipeline_extension='phot', root='msadriz', files=None, 
         
         ############ Combined drizzled spectra
         
-        ## First pass
+        ## First pass - max-clipped median
         sci = np.array([d.data*to_ujy_list[i]
                         for i, d in enumerate(drz)])
         err = np.array([d.err*to_ujy_list[i]
                         for i, d in enumerate(drz)])
-        scim = np.array([d.data*to_ujy_list[i]
-                         for i, d in enumerate(drz)])
         
-        stuck_slits = []
-        if gr in stuck_slit_test:
-            _test = stuck_slit_test[gr]
-            for i, d in enumerate(drz):
-                ok = np.isfinite(d.err + d.data) & (d.dq & 1025 == 0) & (d.err > 0)
-                sn = (d.data/d.err)[ok]
-                slit_sn = np.percentile(sn, _test[0])
-                if slit_sn < _test[1]:
-                    h[f'STUCK{i}'] = True, f'Slit is stuck closed ({slit_sn:.2f})'
-                    if verbose:
-                        slit_file = slits[i].meta.instance['filename'] 
-                        print(f'Slit {slit_file} appears to be stuck closed:'
-                              f' {_test[0]:.1f} S/N = {slit_sn:.2f} < {_test[1]:.1f}')
-                               
-                    stuck_slits.append(i)
+        with warnings.catch_warnings():
+            warnings.simplefilter(action='ignore', category=RuntimeWarning)
+            scima = np.nanmax(sci, axis=0)
         
-        for i in stuck_slits:
-            sci[i] *= np.nan
-            err[i] *= np.nan
-            scim[i] *= np.nan
+        flagged = (sci >= scima)
+        flagged |= (err <= 0) | (~np.isfinite(sci)) | (~np.isfinite(err))
+        flagged |= sci == 0
+        flagged |= ~np.isfinite(sci/err)
+        flagged |= sci/err < sn_threshold
         
-        scima = np.nanmax(sci, axis=0)
-        scim[(scim >= scima)] = np.nan
+        for i in range(len(drz_ids)):
+            ei = err[i,:,:]
+            emask =  ei > err_threshold*np.median(ei[np.isfinite(ei) & (ei > 0)])
+            flagged[i,:,:] |= emask
         
         ivar = 1./err**2
-        ivar[err <= 0] = 0
-        ivarm = ivar*1.
-        ivarm[~np.isfinite(scim)] = 0
-        ivar[~np.isfinite(sci)] = 0
-        ivarm[scim == 0] = 0
-        ivar[sci == 0] = 0
+        sci[flagged] = np.nan
+        ivar[flagged] = 0
 
-        scim[ivarm == 0] = 0
-        sci[ivar == 0] = 0
-
-        sci[ivar == 0] = np.nan
-        avg = np.nanmedian(sci, axis=0)
-        avg_w = ivarm.sum(axis=0)
-
-        ## Second pass
-        sci = np.array([d.data*to_ujy_list[i]
-                        for i, d in enumerate(drz)])
-        err = np.array([d.err*to_ujy_list[i]
-                        for i, d in enumerate(drz)])
-        scim = np.array([d.data*to_ujy_list[i]
-                         for i, d in enumerate(drz)])
+        with warnings.catch_warnings():
+            warnings.simplefilter(action='ignore', category=RuntimeWarning)
+            avg = np.nanmedian(sci, axis=0)
+            
+        avg_w = ivar.sum(axis=0)
+        print('xxx init ', flagged.sum(), sci.size, avg.size)
         
-        for i in stuck_slits:
-            sci[i] *= np.nan
-            err[i] *= np.nan
-            scim[i] *= np.nan
+        ## Subsequent passes - weighted average with outlier rejection
+        for _iter in range(3):
+            sci = np.array([d.data*to_ujy_list[i]
+                            for i, d in enumerate(drz)])
+            err = np.array([d.err*to_ujy_list[i]
+                            for i, d in enumerate(drz)])
+            
+            #scim[(np.abs(sci - avg)/cerr > outlier_threshold)] = np.nan
+            flagged = (np.abs(sci - avg)*np.sqrt(avg_w) > outlier_threshold)
+            
+            flagged |= (err <= 0) | (~np.isfinite(sci)) | (~np.isfinite(err))
+            flagged |= sci == 0
+            flagged |= ~np.isfinite(sci/err)
+            flagged |= sci/err < sn_threshold
+            
+            for i in range(len(drz_ids)):
+                ei = err[i,:,:]
+                emask =  ei > err_threshold*np.median(ei[np.isfinite(ei) & (ei > 0)])
+                flagged[i,:,:] |= emask
+            
+            ivar = 1./err**2
+            sci[flagged] = 0
+            ivar[flagged] = 0
+                        
+            # Weighted combination of unmasked pixels
+            avg = (sci*ivar)[~is_bkg,:].sum(axis=0)/ivar[~is_bkg,:].sum(axis=0)
+            avg_w = ivar[~is_bkg,:].sum(axis=0)
         
-        scima = np.nanmax(sci, axis=0)
-        scim[((sci - avg)/err > outlier_threshold)] = np.nan
-        
-        ivar = 1./err**2
-        ivar[err <= 0] = 0
-        ivarm = ivar*1.
-        ivarm[~np.isfinite(scim)] = 0
-        ivar[~np.isfinite(sci)] = 0
-        ivarm[scim == 0] = 0
-        ivar[sci == 0] = 0
-
-        scim[ivarm == 0] = 0
-        sci[ivar == 0] = 0
-        
-        # Weighted combination of unmasked pixels
-        avg = (scim*ivarm)[~is_bkg,:].sum(axis=0)/ivarm[~is_bkg,:].sum(axis=0)
-        avg_w = ivarm[~is_bkg,:].sum(axis=0)
-        
-        # Set masked pixels to zero
-        msk = ~np.isfinite(avg + avg_w)
-        avg[msk] = 0
-        avg_w[msk] = 0
-        
-        # Background by rolling average array
+            # Set masked pixels to zero
+            msk = ~np.isfinite(avg + avg_w)
+            avg[msk] = 0
+            avg_w[msk] = 0
+            
+        # Background by rolling full drizzled array
         bkg_num = avg*0.
         bkg_w = avg*0
         for s in bkg_parity:
@@ -365,11 +490,6 @@ def drizzle_slitlets(id, pipeline_extension='phot', root='msadriz', files=None, 
 
         bkg_w[:bkg_offset] = 0
         bkg_w[-bkg_offset:] = 0
-        
-        # Set masked back to nan
-        avg[msk] = np.nan
-        avg_w[msk] = np.nan
-
         bkg = bkg_num/bkg_w
         
         # Use master background if supplied
@@ -377,142 +497,271 @@ def drizzle_slitlets(id, pipeline_extension='phot', root='msadriz', files=None, 
             bkg = master_bkg[0]
             bkg_w = master_bkg[1]
         
+        # Set masked back to nan
+        avg[msk] = np.nan
+        avg_w[msk] = np.nan
+                
         # Trace center
-        to_source = (avg.shape[0]-1)//2 + offset_to_source
-        x0 = np.cast[int](np.round(to_source))
-        
+        y0 = (avg.shape[0]-1)//2
+        to_source = y0 + offset_to_source
+
         h['SRCYPIX'] = to_source, 'Expected row of source centering'
         
         # Valid data along wavelength axis
         xvalid = np.isfinite(avg).sum(axis=0) > 0
         xvalid &= nd.binary_erosion(nd.binary_dilation(xvalid, iterations=2), iterations=4)
-        
-        # Make a figure
-        if make_figure:
-            
-            fig, axes = plt.subplots(3,1, figsize=(14,8), sharex=True, sharey=True)
-            axes[0].imshow(avg, **imshow_kws)
-            axes[1].imshow(avg-bkg, **imshow_kws)
-            axes[2].imshow(bkg, **imshow_kws)
-            xr = np.arange(avg.shape[1])[xvalid]
-            axes[0].set_ylabel('Data')
-            axes[1].set_ylabel('Cleaned')
-            axes[2].set_ylabel('Background')
-        
-            for ax in axes:
-                ax.set_yticks([0,x0-bkg_offset, x0,x0+bkg_offset, avg.shape[0]])
-                ax.set_yticklabels([0, -bkg_offset, x0, bkg_offset, avg.shape[0]])
-    
-                ax.grid()
-                ax.set_xlim(xr[0]-5, xr[-1]+5)
-                ax.set_ylim(x0-2*bkg_offset, x0+2*bkg_offset)
-        
-            ax.set_xlabel('pixel')
-            axes[0].set_title(f"{h['SRCNAME']} {gr}")
-            fig.tight_layout(pad=1)
-            
-        else:
-            fig = None
-        
-        
+                
         # Build HDUList
         h['EXTNAME'] = 'SCI'
-        hdul = pyfits.HDUList([pyfits.ImageHDU(data=avg, header=h)])
+        hdul = pyfits.HDUList([pyfits.PrimaryHDU()])
+        hdul.append(pyfits.ImageHDU(data=avg, header=h))
+        
         h['EXTNAME'] = 'WHT'
         hdul.append(pyfits.ImageHDU(data=avg_w, header=h))
+        
         h['EXTNAME'] = 'BKG'
         hdul.append(pyfits.ImageHDU(data=bkg, header=h))
         
+        if output is not None:
+            hdul.writeto(f'{output}-{id}-{gr}.d2d.fits', overwrite=True,
+                         output_verify='fix')
+        
+        if imshow_kws['vmax'] is None:
+            vmax = np.nanpercentile(avg, 95)*2
+            print('xxx', vmax)
+            imshow_kws['vmax'] = vmax
+            imshow_kws['vmin'] = -0.1*vmax
+            reset_vmax = True
+        else:
+            reset_vmax = False
+            
+        # Make a figure
+        if (show_drizzled):
+            dfig = show_drizzled_product(hdul, imshow_kws=imshow_kws)
+            if output is not None:
+                dfig.savefig(f'{output}-{id}-{gr}.d2d.png')
+        else:
+            dfig = None
+
+        if (show_slits):
+            sfig = show_drizzled_slits(slits, sci, ivar, hdul, imshow_kws=imshow_kws,
+                                       with_background=(show_slits > 1))
+            if output is not None:
+                sfig.savefig(f'{output}-{id}-{gr}.slit2d.png')
+        else:
+            sfig = None
+        
+        if reset_vmax:
+            imshow_kws['vmax'] = None
+            
         # Add to data dicts
-        figs[gr] = fig
+        figs[gr] = dfig, sfig
         data[gr] = hdul
         wavedata[gr] = waves
+        all_slits[gr] = slits
+        drz_data[gr] = sci, ivar
         
-    return figs, data, wavedata
+    return figs, data, wavedata, all_slits, drz_data
 
 
-def fit_profile(waves, sci2d, wht2d, profile_slice=None, prf_center=None, prf_sigma=1.0, sigma_bounds=(0.5, 2.0), fit_prf=True, fix_center=False, center_limit=4, trim=0, fix_sigma=False, verbose=True):
+def show_drizzled_slits(slits, sci, ivar, hdul, figsize=FIGSIZE, imshow_kws=IMSHOW_KWS, with_background=False):
     """
+    Make a figure showing drizzled slitlets
     """
-    from photutils.psf import IntegratedGaussianPRF
-    from astropy.modeling.models import Polynomial2D, Gaussian1D
-    from astropy.modeling.fitting import LevMarLSQFitter
+    avg = hdul['SCI'].data
+    xvalid = np.isfinite(avg).sum(axis=0) > 0
+    xr = np.arange(avg.shape[1])[xvalid]
+    bkg = hdul['BKG'].data
+    
+    h = hdul['SCI'].header
+    bkg_offset = h['BKGOFF']
+    x0 = h['SRCYPIX']    
+    y0 = (avg.shape[0]-1)//2
+    
+    msk = (ivar > 0)*1.
+    msk[ivar <= 0] = np.nan
+    
+    fig, axes = plt.subplots(len(slits),1, figsize=figsize, sharex=True, sharey=True)
+    for i, slit in enumerate(slits):
+        axes[i].imshow((sci[i,:,:] - bkg*with_background)*msk[i,:,:], **imshow_kws)
+        axes[i].text(0.02, 0.02*figsize[1]/figsize[0]*len(slits)*2, slit.meta.filename,
+                     ha='left', va='bottom', transform=axes[i].transAxes,
+                     bbox={'fc':'w', 'alpha':0.5,'ec':'None'},
+                     fontsize=6)
+    
+    for ax in axes:
+        ax.set_yticks([0,x0-bkg_offset, x0,x0+bkg_offset, avg.shape[0]])
+        #ax.set_yticklabels([0, -bkg_offset, int(x0), bkg_offset, avg.shape[0]])
+        ax.set_yticklabels([])
+                
+        ax.grid()
+        ax.set_xlim(xr[0]-5, xr[-1]+5)
+        ax.set_ylim(y0-2*bkg_offset, y0+2*bkg_offset)
+        ax.hlines(x0, *ax.get_xlim(), color='k', linestyle='-', alpha=0.1)
+
+    ax.set_xlabel('pixel')
+    axes[0].set_title(f"{h['SRCNAME']} {h['GRATING']}-{h['FILTER']}")
+    fig.tight_layout(pad=0.5)
+    
+    return fig
+
+
+def show_drizzled_product(hdul, figsize=FIGSIZE, imshow_kws=IMSHOW_KWS):
+    """
+    Make a figure showing drizzled product
+    """
+    
+    avg = hdul['SCI'].data
+    xvalid = np.isfinite(avg).sum(axis=0) > 0
+    xr = np.arange(avg.shape[1])[xvalid]
+    bkg = hdul['BKG'].data
+    
+    h = hdul['SCI'].header
+    bkg_offset = h['BKGOFF']
+    
+    x0 = h['SRCYPIX']    
+    y0 = (avg.shape[0]-1)//2
+    
+    fig, axes = plt.subplots(3,1, figsize=figsize, sharex=True, sharey=True)
+    
+    axes[0].imshow(avg, **imshow_kws)
+    axes[1].imshow(avg-bkg, **imshow_kws)
+    axes[2].imshow(bkg, **imshow_kws)
+    
+    # Labels
+    for i, label in enumerate(['Data','Cleaned','Background']):
+        axes[i].text(0.02, 0.02*figsize[1]/figsize[0]*3*2, label,
+                     ha='left', va='bottom', transform=axes[i].transAxes,
+                     bbox={'fc':'w', 'alpha':0.5,'ec':'None'},
+                     fontsize=8)
+        
+    for ax in axes:
+        ax.set_yticks([0,x0-bkg_offset, x0,x0+bkg_offset, avg.shape[0]])
+        ax.set_yticklabels([])
+        ax.hlines(x0, *ax.get_xlim(), color='k', linestyle='-', alpha=0.1)
+        
+        ax.grid()
+        ax.set_xlim(xr[0]-5, xr[-1]+5)
+        ax.set_ylim(y0-2*bkg_offset, y0+2*bkg_offset)
+
+    ax.set_xlabel('pixel')
+    axes[0].set_title(f"{h['SRCNAME']} {h['GRATING']}-{h['FILTER']}")
+    fig.tight_layout(pad=0.5)
+    
+    return fig
+
+
+def make_optimal_extraction(waves, sci2d, wht2d, profile_slice=None,
+                            prf_center=None, prf_sigma=1.0, sigma_bounds=(0.5, 2.5), 
+                            center_limit=4,
+                            fit_prf=True, fix_center=False, fix_sigma=False, trim=0,
+                            bkg_offset=6, bkg_parity=[-1,1], verbose=True, **kwargs):
+    """
+    Optimal extraction from 2D arrays
+    """
     import scipy.ndimage as nd
     import astropy.units as u
+    from scipy.optimize import least_squares
+    
+    from .version import __version__ as msaexp_version
     
     sh = wht2d.shape
     yp, xp = np.indices(sh)
     
+    ok = np.isfinite(sci2d*wht2d) & (wht2d > 0)
+    
     if profile_slice is not None:
+        if not isinstance(profile_slice, slice):
+            if isinstance(profile_slice[0], int):
+                # pixels
+                profile_slice = slice(*profile_slice)
+            else:
+                # Wavelengths interpolated on pixel grid
+                sh = drizzled_slits[0].data.shape
+                xpix = np.arange(sh[1])
+                ypix = np.zeros(sh[1]) + sh[0]/2
+    
+                _wcs = drizzled_slits[0].meta.wcs
+                _, _, wave0 = _wcs.forward_transform(xpix, ypix)
+                xsl = np.cast[int](np.round(np.interp(profile_slice, wave0, xpix)))
+                xsl = np.clip(xsl, 0, sh[1])
+                print(f'Wavelength slice: {profile_slice} > {xsl} pix')
+                profile_slice = slice(*xsl)
+            
         prof1d = np.nansum((sci2d * wht2d)[:,profile_slice], axis=1) 
         prof1d /= np.nansum(wht2d[:,profile_slice], axis=1)
+            
         slice_limits = profile_slice.start, profile_slice.stop
+        
+        pmask = ok & False
+        pmask[:,profile_slice] = True
+        ok &= ~pmask
+        
     else:
         prof1d = np.nansum(sci2d * wht2d, axis=1) / np.nansum(wht2d, axis=1)
         slice_limits = 0, sh[1]
     
-    ok = np.isfinite(prof1d)
-    # Trim edges
-    ok[np.where(ok)[0][:1]] = False
-    ok[np.where(ok)[0][-1:]] = False
-    
-    ok &= (prof1d > 0)
-    
     xpix = np.arange(sh[0])
-    # ytrace = np.nanmedian(ytr)
-    # print('xxx', ytrace, sh[0]/2)
-    ytrace = sh[0]/2.
+    ytrace = (sh[0]-1)/2.
     x0 = np.arange(sh[0]) - ytrace
     y0 = yp - ytrace
-    
+        
     if prf_center is None:
-        msk = ok & (np.abs(x0) < center_limit)
-        prf_center = np.nanargmax(prof1d*msk) - sh[0]/2.
+        prf_center = np.nanargmax(prof1d*msk) - (sh[0]-1)/2.
         if verbose:
             print(f'Set prf_center: {prf_center} {sh} {ok.sum()}')
-        
-    ok &= np.abs(x0 - prf_center) < center_limit
     
-    prf = IntegratedGaussianPRF(x_0=0, y_0=prf_center, sigma=prf_sigma)
-    gau = Gaussian1D(mean=prf_center, stddev=prf_sigma)
+    msg = f"msaexp.drizzle.extract_from_hdul: Initial center = {prf_center:6.2f},"
+    msg += f" sigma = {prf_sigma:6.2f}"
+    grizli.utils.log_comment(grizli.utils.LOGFILE, msg, verbose=verbose, show_date=False)
     
-    if (fit_prf > 0) & (ok.sum() > (2 - fix_center - fix_sigma)):
-        fitter = LevMarLSQFitter()
-        
-        if fit_prf == 2:
-            gau.bounds['stddev'] = sigma_bounds
-            gfit = fitter(gau, x0[ok], prof1d[ok])
-            prf.y_0 = gfit.mean
-            prf.sigma = gfit.stddev
-            sigma_bounds = [0.8, 1.5*gfit.stddev]
-            prf_center = gfit.mean
-            # print(gfit)
-            
-        prf.fixed['x_0'] = True
-        prf.fixed['y_0'] = fix_center
-        prf.fixed['sigma'] = fix_sigma    
-        prf.bounds['sigma'] = sigma_bounds
-        prf.bounds['y_0'] = (prf_center-center_limit, prf_center+center_limit)
-        
-        
-        pfit = fitter(prf, x0[ok]*0., x0[ok], prof1d[ok])
-        
-        if verbose:
-            msg = f'fit_prf: center = {pfit.y_0.value:.2f}'
-            msg += f'. sigma = {pfit.sigma.value:.2f}'
-            print(msg)
-        
+    ############# 
+    #### Integrated gaussian profile
+    fit_type = 3 - 2*fix_center - 1*fix_sigma
+    
+    wht_mask = wht2d*1
+    wht_mask[~ok] = 0.
+    
+    if fit_type == 0:
+        args = (waves, sci2d, wht_mask, prf_center, prf_sigma,
+                bkg_offset, bkg_parity, 3, 1, (verbose > 1))
+        pnorm, pmodel = utils.objfun_prf([prf_center, prf_sigma], *args)
+        profile2d = pmodel/pnorm
     else:
-        pfit = prf
-    
-    #plt.plot(x0, prof1d)
-    #plt.plot(x0, pfit(x0*0, x0))
+        # Fit it
+        if fix_sigma:
+            p0 = [prf_center]
+            bounds = (-center_limit, center_limit)
+        elif fix_center:
+            p0 = [prf_sigma]
+            bounds = sigma_bounds
+        else:
+            p0 = [prf_center, prf_sigma]
+            bounds = ((-center_limit+prf_center, sigma_bounds[0]),
+                      (center_limit+prf_center, sigma_bounds[1]))
+            
+        args = (waves, sci2d, wht_mask, prf_center, prf_sigma,
+                bkg_offset, bkg_parity, fit_type, 1, (verbose > 1))
+        lmargs = (waves, sci2d, wht_mask, prf_center, prf_sigma,
+                  bkg_offset, bkg_parity, fit_type, 2, (verbose > 1))
 
-    # Renormalize for 1D
-    pfit.flux = prf.sigma.value*np.sqrt(2*np.pi)
+        _res = least_squares(utils.objfun_prf, p0, args=lmargs, method='trf',
+                             bounds=bounds, loss='huber')
+        
+        pnorm, pmodel = utils.objfun_prf(_res.x, *args)
+        profile2d = pmodel/pnorm
+        pmask = (profile2d > 0) & np.isfinite(profile2d)
+        profile2d[~pmask] = 0
+        
+        if fix_sigma:
+            fit_center = _res.x[0]
+            fit_sigma = prf_sigma
+        elif fix_center:
+            fit_sigma = _res.x[0]
+            fit_center = prf_center
+        else:
+            fit_center, fit_sigma = _res.x
     
-
-    profile2d = pfit(y0*0., y0)
     wht1d = np.nansum(wht2d*profile2d**2, axis=0)
     sci1d = np.nansum(sci2d*wht2d*profile2d, axis=0) / wht1d
     
@@ -530,31 +779,29 @@ def fit_profile(waves, sci2d, wht2d, profile_slice=None, prf_center=None, prf_si
     err1d = np.sqrt(1/wht1d)
     err1d[wht1d <= 0] = 0
     
-    #plt.imshow(profile2d)
-    #plt.plot(sci1d)
-    
     ####### Make tables
     # Flux conversion
-    to_ujy = 1. # Already applied in drizzle_slitlets
     # to_ujy = 1.e12*5.e-13 #drizzled_slits[0].meta.photometry.pixelarea_steradians
+    to_ujy = 1.
     
     spec = grizli.utils.GTable()
-    spec.meta['VERSION'] = msaexp.__version__, 'msaexp software version'
+    spec.meta['VERSION'] = msaexp_version, 'msaexp software version'
         
-    # spec.meta['TOMUJY'] = to_ujy, 'Conversion from pixel values to microJansky'
-    spec.meta['PROFCEN'] = pfit.y_0.value, 'PRF profile center'
-    spec.meta['PROFSIG'] = pfit.sigma.value, 'PRF profile sigma'
+    spec.meta['TOMUJY'] = to_ujy, 'Conversion from pixel values to microJansky'
+    spec.meta['PROFCEN'] = fit_center, 'PRF profile center'
+    spec.meta['PROFSIG'] = fit_sigma, 'PRF profile sigma'
     spec.meta['PROFSTRT'] = slice_limits[0], 'Start of profile slice'
     spec.meta['PROFSTOP'] = slice_limits[1], 'End of profile slice'
     spec.meta['YTRACE'] = ytrace, 'Expected center of trace'
     
     prof_tab = grizli.utils.GTable()
-    prof_tab.meta['VERSION'] = msaexp.__version__, 'msaexp software version'
+    prof_tab.meta['VERSION'] = msaexp_version, 'msaexp software version'
+    
     prof_tab['pix'] = x0
     prof_tab['profile'] = prof1d
     prof_tab['pfit'] = pfit1d
-    prof_tab.meta['PROFCEN'] = pfit.y_0.value, 'PRF profile center'
-    prof_tab.meta['PROFSIG'] = pfit.sigma.value, 'PRF profile sigma'
+    prof_tab.meta['PROFCEN'] = fit_center, 'PRF profile center'
+    prof_tab.meta['PROFSIG'] = fit_sigma, 'PRF profile sigma'
     prof_tab.meta['PROFSTRT'] = slice_limits[0], 'Start of profile slice'
     prof_tab.meta['PROFSTOP'] = slice_limits[1], 'End of profile slice'
     prof_tab.meta['YTRACE'] = ytrace, 'Expected center of trace'
@@ -570,4 +817,58 @@ def fit_profile(waves, sci2d, wht2d, profile_slice=None, prf_center=None, prf_si
     sci2d[~msk] = 0
     wht2d[~msk] = 0
     
-    return sci2d, wht2d, profile2d, spec, prof_tab    
+    return sci2d*to_ujy, wht2d/to_ujy**2, profile2d, spec, prof_tab
+
+
+def extract_from_hdul(hdul, prf_center=None, master_bkg=None, verbose=True, **kwargs):
+    """
+    """
+        
+    if master_bkg is None:
+        bkg_i = hdul['BKG'].data
+    else:
+        bkg_i = master_bkg
+    
+    sci = hdul['SCI']
+    sci2d = sci.data - bkg_i
+    
+    wht2d = hdul['WHT'].data*1
+
+    waves = utils.get_standard_wavelength_grid(sci.header['GRATING'].lower(),
+                                               sample=sci.header['WSAMPLE'],
+                                               log_step=sci.header['LOGWAVE'])
+    
+    if prf_center is None:
+        prf_center = sci.header['SRCYPIX'] - (sci.data.shape[0]-1)/2. - 1
+    
+    _data = make_optimal_extraction(waves, sci2d, wht2d,
+                                    prf_center=prf_center,
+                                    verbose=verbose,
+                                    **kwargs,
+                                   )
+
+    _sci2d, _wht2d, profile2d, spec, prof = _data
+
+    hdul = pyfits.HDUList()
+    hdul.append(pyfits.BinTableHDU(data=spec, name='SPEC1D'))
+
+    header = sci.header
+
+    for k in spec.meta:
+        header[k] = spec.meta[k]
+    
+    msg = f"msaexp.drizzle.extract_from_hdul:  Output center = {header['PROFCEN']:6.2f}"
+    msg += f", sigma = {header['PROFSIG']:6.2f}"
+    grizli.utils.log_comment(grizli.utils.LOGFILE, msg, verbose=verbose, show_date=False)
+
+    hdul.append(pyfits.ImageHDU(data=sci2d, header=header, name='SCI'))
+    hdul.append(pyfits.ImageHDU(data=wht2d, header=header, name='WHT'))
+    hdul.append(pyfits.ImageHDU(data=profile2d, header=header, name='PROFILE'))
+
+    hdul.append(pyfits.BinTableHDU(data=prof, name='PROF1D'))
+
+    for k in hdul['SCI'].header:
+        if k not in hdul['SPEC1D'].header:
+            hdul['SPEC1D'].header[k] = hdul['SCI'].header[k]
+    
+    return hdul

--- a/msaexp/utils.py
+++ b/msaexp/utils.py
@@ -1698,6 +1698,7 @@ def calculate_psf_fwhm():
     """
     import scipy.stats
     import webbpsf
+    import matplotlib.pyplot as plt
     
     nspec = webbpsf.NIRSpec()
     nspec.image_mask = 'S200A1' # 0.2 arcsec slit

--- a/msaexp/utils.py
+++ b/msaexp/utils.py
@@ -1,9 +1,11 @@
 """
 """
 import os
+import warnings
 import numpy as np
 import astropy.io.fits as pyfits
 
+import grizli.utils
 
 def summary_from_metafiles():
     """
@@ -209,6 +211,102 @@ def detector_bounding_box(file):
         yaml.dump(slit_borders, stream=fp)
 
     return slit_borders
+
+
+def slit_metadata_to_header(slit, key='', header=None):
+    """
+    Get selected metadata.
+    
+    This would be similar to
+    
+    .. code-block:: python
+        :dedent:
+    
+        from stdatamodels import fits_support
+        hdul, _asdf = fits_support.to_fits(slit._instance, schema=slit._schema)
+    
+    and getting the keywords from `hdul`, but here the keywords are renamed slightly to
+    allow adding the `key` suffix.
+    
+    Parameters
+    ----------
+    slit : `jwst.datamodels.SlitModel`
+        Slit data model
+    
+    key : str, int
+        Key that will be appended to header keywords, e.g., ``header[f'FILE{key}']``.  Should
+        have just one or two characters to avoid making HIERARCH keywords longer than the 
+        FITS standard eight characters.
+    
+    header : `~astropy.io.fits.Header`
+        Add keys to existing header
+    
+    Returns
+    -------
+    header : `~astropy.io.fits.Header`
+    
+    """
+    if header is None:
+        h = pyfits.Header()
+    else:
+        h = header
+        
+    meta = slit.meta.instance
+    
+    h[f'FILE{key}']    = meta['filename'], 'Data filename'
+    h[f'CALVER{key}']  = (meta['calibration_software_version'], 'Calibration software version')
+    h[f'CRDS{key}']    = (meta['ref_file']['crds']['context_used'], 'CRDS context')
+    
+    h[f'GRAT{key}']    = meta['instrument']['grating'], 'Instrument grating'
+    h[f'FILTER{key}']  = meta['instrument']['filter'], 'Instrument filter'
+    
+    h[f'MSAMET{key}']  = meta['instrument']['msa_metadata_file'], 'MSAMETF metadata file'
+    h[f'MSAID{key}']   = meta['instrument']['msa_metadata_id'], 'MSAMETF metadata id'
+    h[f'MSACONF{key}'] = (meta['instrument']['msa_configuration_id'],
+                        'MSAMETF metadata configuration id')
+                       
+    h[f'SLITID{key}'] = slit.slitlet_id, 'slitlet_id from MSA file'
+    h[f'SRCNAM{key}'] = slit.source_name, 'source_name from MSA file'
+    h[f'SRCID{key}']  = slit.source_id, 'source_id from MSA file'
+    h[f'SRCRA{key}']  = slit.source_ra, 'source_ra from MSA file'
+    h[f'SRCDEC{key}'] = slit.source_dec, 'source_dec from MSA file'
+    
+    h[f'PIXSR{key}']  = slit.meta.photometry.pixelarea_steradians, 'Pixel area, sr'
+    h[f'TOUJY{key}']  = 1.e12*h[f'PIXSR{key}'], 'Conversion to uJy/pix'
+    
+    h[f'DETECT{key}'] = meta['instrument']['detector'], 'Instrument detector name'
+    h[f'XSTART{key}'] = slit.ystart, 'Left detector pixel of 2D cutout'
+    h[f'XSIZE{key}']  = slit.xsize, 'X size of 2D cutout'
+    h[f'YSTART{key}'] = slit.ystart, 'Lower detector pixel of 2D cutout'
+    h[f'YSIZE{key}']  = slit.ysize, 'Y size of 2D cutout'
+
+    h[f'RA_REF{key}'] = meta['wcsinfo']['ra_ref'],  'Exposure RA reference position'
+    h[f'DE_REF{key}'] = meta['wcsinfo']['dec_ref'], 'Exposure Dec reference position'
+    h[f'RL_REF{key}'] = meta['wcsinfo']['roll_ref'], 'Exposure roll referencev'
+    h[f'V2_REF{key}'] = meta['wcsinfo']['v2_ref'],  'Exposure V2 reference position'
+    h[f'V3_REF{key}'] = meta['wcsinfo']['v3_ref'],  'Exposure V3 reference position'
+    h[f'V3YANG{key}'] = meta['wcsinfo']['v3yangle'], 'Exposure V3 y angle'
+    
+    h[f'RA_V1{key}']  = meta['pointing']['ra_v1'], '[deg] RA of telescope V1 axis'
+    h[f'DEC_V1{key}'] = meta['pointing']['dec_v1'], '[deg] Dec of telescope V1 axis'
+    h[f'PA_V3{key}']  = meta['pointing']['pa_v3'], '[deg] Position angle of V3 axis'
+    
+    h[f'EXPSTR{key}'] = meta['exposure']['start_time_mjd'], 'Exposure start MJD'
+    h[f'EXPEND{key}'] = meta['exposure']['start_time_mjd'], 'Exposure end MJD'
+    h[f'EFFEXP{key}'] = (meta['exposure']['effective_exposure_time'],
+                         'Effective exposure time')
+
+    h[f'DITHN{key}'] = meta['dither']['position_number'], 'Dither position number'
+    h[f'DITHX{key}'] = meta['dither']['x_offset'], 'Dither x offset'
+    h[f'DITHY{key}'] = meta['dither']['y_offset'], 'Dither y offset'
+    h[f'DITHT{key}'] = meta['dither']['nod_type'], 'Dither nod type'
+    
+    h[f'NFRAM{key}'] = meta['exposure']['nframes'], 'Number of frames'
+    h[f'NGRP{key}']  = meta['exposure']['ngroups'], 'Number of groups'
+    h[f'NINTS{key}'] = meta['exposure']['nints'], 'Number of integrations'
+    h[f'RDPAT{key}'] = meta['exposure']['readpatt'], 'Readout pattern'
+    
+    return h
 
 
 def slit_trace_center(slit, with_source_ypos=True, index_offset=0.):
@@ -543,13 +641,17 @@ def build_regular_wavelength_wcs(slits, pscale_ratio=1, keep_wave=False, wave_sc
     
     # Set linear dispersion
     if wave_range is None:
-        lmin = np.nanmin(target_waves)
-        lmax = np.nanmax(target_waves)
+        with warnings.catch_warnings():
+            warnings.simplefilter(action='ignore', category=RuntimeWarning)
+            lmin = np.nanmin(target_waves)
+            lmax = np.nanmax(target_waves)
     else:
         lmin, lmax = wave_range
         
     if wave_step is None:
-        dlam = np.nanmedian(np.diff(target_waves))*wave_scale
+        with warnings.catch_warnings():
+            warnings.simplefilter(action='ignore', category=RuntimeWarning)
+            dlam = np.nanmedian(np.diff(target_waves))*wave_scale
     else:
         dlam = wave_step*1.
     
@@ -574,18 +676,24 @@ def build_regular_wavelength_wcs(slits, pscale_ratio=1, keep_wave=False, wave_sc
             dl = np.diff(target_waves)
             target_waves = np.append(target_waves, target_waves[:-1]+dl/2.)
             target_waves.sort()
+                    
+        with warnings.catch_warnings():
+            warnings.simplefilter(action='ignore', category=RuntimeWarning)
             
-        lmin = np.nanmin(target_waves)
-        lmax = np.nanmax(target_waves)
-        dlam = np.nanmedian(np.diff(target_waves))
+            lmin = np.nanmin(target_waves)
+            lmax = np.nanmax(target_waves)
+            dlam = np.nanmedian(np.diff(target_waves))
         
     if wave_array is not None:
         msg = f'Set user-defined wavelength grid (size={wave_array.size})'
         
         target_waves = wave_array*1.
-        lmin = np.nanmin(target_waves)
-        lmax = np.nanmax(target_waves)
-        dlam = np.nanmedian(np.diff(target_waves))
+        with warnings.catch_warnings():
+            warnings.simplefilter(action='ignore', category=RuntimeWarning)
+            
+            lmin = np.nanmin(target_waves)
+            lmax = np.nanmax(target_waves)
+            dlam = np.nanmedian(np.diff(target_waves))
         
     if verbose:
         print('build_regular_wavelength_wcs: ' + msg)
@@ -749,7 +857,9 @@ def build_regular_wavelength_wcs(slits, pscale_ratio=1, keep_wave=False, wave_sc
     return target_waves, header, data_size, output_wcs
 
 
-def build_slit_centered_wcs(slit, waves, pscale_ratio=1, ypad=0, force_nypix=21, slit_center=0., center_on_source=False, get_from_ypos=True, phase=0, fix_slope=None, **kwargs):
+def build_slit_centered_wcs(slit, waves, pscale_ratio=1, ypad=0, force_nypix=21, slit_center=0., center_on_source=False, get_from_ypos=True, phase=-0.5, fix_slope=None, **kwargs):
+    """
+    """
     
     from gwcs import wcstools
     
@@ -776,30 +886,34 @@ def build_slit_centered_wcs(slit, waves, pscale_ratio=1, ypad=0, force_nypix=21,
                           single=True,
                           blendheaders=True,
                           pixfrac=1.0,
-                          kernel='point',
+                          kernel='square',
                           fillval=0,
                           wht_type='ivm',
                           good_bits=0,
                           pscale_ratio=1.0,
                           pscale=None)
 
-        _data = build_regular_wavelength_wcs([sc], center_on_source=False, 
-                                                          wave_array=waves, 
-                                                          force_nypix=force_nypix,
-                                                          ypad=ypad,
-                                                          pscale_ratio=pscale_ratio,
-                                                          verbose=False,
-                                                          fix_slope=fix_slope) 
+        _data = build_regular_wavelength_wcs([sc],
+                                             center_on_source=False, 
+                                             wave_array=waves, 
+                                             force_nypix=force_nypix,
+                                             ypad=ypad,
+                                             pscale_ratio=pscale_ratio,
+                                             verbose=False,
+                                             fix_slope=fix_slope) 
 
-        _waves, _header, _drz = drizzle_slits_2d([sc], build_data=_data,
-                                                          drizzle_params=DRIZZLE_PARAMS)
-    
-        prof = np.nansum(_drz[0].data, axis=1)
+        _waves, _header, _drz = drizzle_slits_2d([sc],
+                                                 build_data=_data,
+                                                 drizzle_params=DRIZZLE_PARAMS,
+                                                 )
+        
+        with warnings.catch_warnings():
+            warnings.simplefilter(action='ignore', category=RuntimeWarning)
+            prof = np.nansum(_drz[0].data, axis=1)
+        
         if prof.max() == 0:
             return _data
         
-        # plt.plot(prof)
-    
         xc = (np.arange(len(prof))*prof).sum()/prof.sum()
         yoff = xc - (force_nypix-1)/2 + phase
     
@@ -807,12 +921,14 @@ def build_slit_centered_wcs(slit, waves, pscale_ratio=1, ypad=0, force_nypix=21,
     
     slit.drizzle_slit_offset = yoff
     
-    _xdata = build_regular_wavelength_wcs([slit], center_on_source=False, 
-                                                       wave_array=waves, 
-                                                       force_nypix=force_nypix,
-                                                       force_yoffset=yoff,
-                                                       ypad=0, verbose=False,
-                                                       fix_slope=fix_slope) 
+    _xdata = build_regular_wavelength_wcs([slit],
+                                          center_on_source=False, 
+                                          wave_array=waves, 
+                                          force_nypix=force_nypix,
+                                          force_yoffset=yoff,
+                                          ypad=0, verbose=False,
+                                          fix_slope=fix_slope,
+                                          ) 
     
     return _xdata
 
@@ -1256,7 +1372,7 @@ def drizzle_2d_pipeline(slits, output_root=None, standard_waves=True, drizzle_pa
     return hdul
 
 
-def drizzled_hdu_figure(hdul, tick_steps=None, xlim=None, subplot_args=dict(figsize=(10, 4), height_ratios=[1,3], width_ratios=[10,1]), cmap='plasma_r', ymax=None, vmin=-0.3, z=None, ny=None, output_root=None, unit='fnu'):
+def drizzled_hdu_figure(hdul, tick_steps=None, xlim=None, subplot_args=dict(figsize=(10, 4), height_ratios=[1,3], width_ratios=[10,1]), cmap='plasma_r', ymax=None, vmin=-0.15, z=None, ny=None, output_root=None, unit='fnu', recenter=True):
     """
     Figure showing drizzled hdu
     """
@@ -1290,11 +1406,21 @@ def drizzled_hdu_figure(hdul, tick_steps=None, xlim=None, subplot_args=dict(figs
                    
     axes[0].set_yticklabels([])
     y0 = hdul['SPEC1D'].header['YTRACE'] + hdul['SPEC1D'].header['PROFCEN']
+    
+    if 'BKGOFF' in hdul['SCI'].header:
+        yt = hdul['SCI'].header['BKGOFF']
+    else:
+        yt = 5
+    
     if ny is not None:
         axes[0].set_ylim(y0-ny, y0+ny)
         axes[0].set_yticks([y0])
+        if recenter:
+            axes[0].set_ylim(y0-2*ny, y0+2*ny)
     else:
-        axes[0].set_yticks([y0-4, y0+4])
+        axes[0].set_yticks([y0-yt, y0+yt])
+        if recenter:
+            axes[0].set_ylim(y0-2*yt, y0+2*yt)
         
     # Extraction profile
     ap = a2d[0][1]
@@ -1304,7 +1430,7 @@ def drizzled_hdu_figure(hdul, tick_steps=None, xlim=None, subplot_args=dict(figs
     sh = hdul['SCI'].data.shape
     sli = (hdul['PROF1D'].header['PROFSTRT'],
            hdul['PROF1D'].header['PROFSTOP'])
-           
+    
     if sli != (0, sh[1]):
         
         dy = np.diff(axes[0].get_ylim())[0]
@@ -1325,14 +1451,18 @@ def drizzled_hdu_figure(hdul, tick_steps=None, xlim=None, subplot_args=dict(figs
                 ha='right', va='center',
                 bbox={'fc':'w', 'ec':'None', 'alpha':1.},
                 transform=ap.transAxes, fontsize=7)
-    #
+    
     ap.spines.right.set_visible(False)
     ap.spines.top.set_visible(False)
     
     ap.set_ylim(axes[0].get_ylim())
-    ap.set_yticks([y0-4, y0+4])
+    ap.set_yticks([y0-yt, y0+yt])
+    
+    if recenter:
+        ap.set_ylim(y0-2*yt, y0+2*yt)
+        
     ap.grid()
-    ap.set_xlim(-0.5, 1)
+    ap.set_xlim(-0.5, 1.3)
     ap.set_xticklabels([])
     ap.set_yticklabels([])
     
@@ -1418,11 +1548,12 @@ def drizzled_hdu_figure(hdul, tick_steps=None, xlim=None, subplot_args=dict(figs
         xticks = [f'{w:0.2}' for w in wrest[in_range]]
         #xticks[0] = f'z={z:.3f}' #' {xticks[0]}'
         axes[0].set_xticklabels(xticks)
-        axes[1].text(0.03,0.96, f'z={z:.4f}',
+        axes[1].text(0.03,0.90, f'z={z:.4f}',
                       ha='left', va='top',
                       transform=axes[1].transAxes,
                       fontsize=8, 
-                      bbox={'fc':'w', 'alpha':0.5, 'ec':'None'})
+                      bbox={'fc':'w', 'alpha':0.5, 'ec':'None'},
+                      )
                       
                      
         mrest = np.arange(0.1, 1.91, 0.01)
@@ -1437,11 +1568,16 @@ def drizzled_hdu_figure(hdul, tick_steps=None, xlim=None, subplot_args=dict(figs
         axes[0].grid()
     
     if output_root is not None:
-        axes[1].text(0.97,0.96, output_root,
-                      ha='right', va='top',
-                      transform=axes[1].transAxes,
-                      fontsize=8, 
-                      bbox={'fc':'w', 'alpha':0.5, 'ec':'None'})
+        label = f"{output_root} {hdul['SCI'].header['SRCNAME']}"
+    else:
+        label = f"{hdul['SCI'].header['SRCNAME']}"
+        
+    axes[1].text(0.03,0.97, label,
+                  ha='left', va='top',
+                  transform=axes[1].transAxes,
+                  fontsize=8, 
+                  bbox={'fc':'w', 'alpha':0.5, 'ec':'None'},
+                  )
         
     if xlim is not None:
         xvi = np.interp(xlim, sp['wave'], np.arange(len(sp)))
@@ -1554,6 +1690,167 @@ def extract_all():
         hdul.append(pyfits.ImageHDU(data=profile2d, header=header, name='PROFILE'))
         
         hdul.flush()
+
+
+def calculate_psf_fwhm():
+    """
+    Use WebbPSF to calculate the FWHM as a function of wavelength assuming 0.2" fixed slit
+    """
+    import scipy.stats
+    import webbpsf
+    
+    nspec = webbpsf.NIRSpec()
+    nspec.image_mask = 'S200A1' # 0.2 arcsec slit
+
+    psfs = {}
+    for wave in [0.6, 0.7, 0.8, 0.9, 1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 5.5]:
+        print(wave)
+        psfs[wave] = nspec.calc_psf(monochromatic=wave*1.e-6, oversample=4, 
+                                    detector_oversample=4)
+    #
+    norm = scipy.stats.norm()
+
+    N = len(psfs)
+    fig, axes = plt.subplots(2,N, figsize=(2*len(psfs),4), sharex=False, sharey=False)
+
+    fwhm_wave = []
+
+    for i, w in enumerate(psfs):
+        psf = psfs[w]
+        ax = axes[0][i]
+        ext = 'OVERSAMP'
+        ax.imshow(np.log10(psf[ext].data))
+        ax.set_xticklabels([])
+        ax.set_yticklabels([])
+                       
+        prof = psf[ext].data.sum(axis=1)
+        ax = axes[1][i]
+        Nx = len(prof)
+        ax.plot(prof/prof.sum(), marker='.')
+        cdf = np.cumsum(prof/prof.sum())
+        ax.plot(cdf/2)
+    
+        x = np.arange(Nx)
+        fwhm = np.diff(np.interp(norm.cdf(np.array([-1,1])*2.35/2), cdf, x))
+        fwhm_wave.append(fwhm[0])
+    
+        print(w, fwhm/4)
+        ax.set_ylim(-0.1, 0.5)
+        ax.set_xlim(Nx/2-20, Nx/2+20)
+        ax.set_xticklabels([])
+        ax.set_yticklabels([])
+
+
+def get_nirspec_psf_fwhm(wave):
+    """
+    Get PSF FWHM in pix based on WebbPSF
+    
+    Parameters
+    ----------
+    wave : float, array-like
+        Wavelength in microns
+    
+    """
+    fwhm_table = grizli.utils.read_catalog("""# wave fwhm_pix
+    0.6 1.04
+    0.7 0.80
+    0.8 0.67
+    0.9 0.63
+    1.0 0.62
+   1.25 0.68
+    1.5 0.79
+    2.0 0.89
+    2.5 0.95
+    3.0 1.08
+    4.0 1.41
+    5.0 1.78
+    5.5 1.94""")
+    
+    fwhm = np.interp(wave, fwhm_table['wave'], fwhm_table['fwhm_pix'],
+                     left=fwhm_table['fwhm_pix'][0],
+                     right=fwhm_table['fwhm_pix'][-1])
+    
+    return fwhm
+
+
+def make_nirspec_gaussian_profile(waves, sigma=0.5, ycenter=0., ny=31, weight=1, bkg_offset=6, bkg_parity=[-1,1]):
+    """
+    Make a pixel-integrated Gaussian profile
+    """
+    import scipy.special
+    
+    yp, xp = np.indices((ny+1, len(waves)))
+    y0 = (ny-1)/2
+    
+    psf_fwhm = get_nirspec_psf_fwhm(waves)
+    sig = np.sqrt((psf_fwhm/2.35)**2 + sigma**2)
+    
+    ysig = (yp - y0 - 0.5 - ycenter) / sig
+    
+    cdf = 1/2*(1 + scipy.special.erf(ysig/np.sqrt(2)))
+    
+    prf = np.diff(cdf, axis=0)
+    
+    if bkg_offset is not None:
+        bkgn = prf*0.
+        bkgd = bkgn*0
         
+        for p in bkg_parity:
+            bkgn += np.roll(prf*weight, p*bkg_offset, axis=0)
+            bkgd += np.roll(weight, p*bkg_offset, axis=0)
+            
+        prf -= bkgn/bkgd
+        
+    return prf
+
+
+def objfun_prf(params, waves, sci2d, wht2d, ycenter, sigma, bkg_offset, bkg_parity, fit_type, ret, verbose):
+    """
+    Objective function for fitting the 2D profile
+    """
+    if fit_type == 1:
+        sigma = params[0]
+    elif fit_type == 2:
+        ycenter = params[0]
+    else:
+        ycenter, sigma = params
+        
+    ny = sci2d.shape[0]
+    prf = make_nirspec_gaussian_profile(waves,
+                           sigma=sigma,
+                           ycenter=ycenter,
+                           ny=ny,
+                           weight=wht2d,
+                           bkg_offset=bkg_offset,
+                           bkg_parity=bkg_parity)
+    
+    prf *= prf > 0
+    
+    ok = np.isfinite(sci2d*prf*wht2d) & (wht2d > 0) & (sci2d != 0) #& (prf != 0)
+    norm = (sci2d*prf*wht2d)[ok].sum() / (prf**2*wht2d)[ok].sum()
+    model = norm*prf
+        
+    if 0:
+        p2 = prf*1
+        p2 *= (p2 > 0)
+
+        num = np.nansum((sci2d*p2*wht2d), axis=0)
+        den = np.nansum((p2**2*wht2d), axis=0)
+        norm = num/den
+
+        model = norm*prf
+    
+    chi = (sci2d - model)*np.sqrt(wht2d)
+    
+    chi2 = (chi[ok]**2).sum()
+    if verbose:
+        print(params, chi2)
+    
+    if ret == 1:
+        return norm, model
+    elif ret == 2:
+        return chi[ok].flatten()
+    elif ret == 3:
+        return chi2
     
         

--- a/msaexp/utils.py
+++ b/msaexp/utils.py
@@ -1567,17 +1567,18 @@ def drizzled_hdu_figure(hdul, tick_steps=None, xlim=None, subplot_args=dict(figs
         axes[0].set_xticklabels([])
         axes[0].grid()
     
-    if output_root is not None:
-        label = f"{output_root} {hdul['SCI'].header['SRCNAME']}"
-    else:
-        label = f"{hdul['SCI'].header['SRCNAME']}"
+    if 'SRCNAME' in hdul['SCI'].header:
+        if output_root is not None:
+            label = f"{output_root} {hdul['SCI'].header['SRCNAME']}"
+        else:
+            label = f"{hdul['SCI'].header['SRCNAME']}"
         
-    axes[1].text(0.03,0.97, label,
-                  ha='left', va='top',
-                  transform=axes[1].transAxes,
-                  fontsize=8, 
-                  bbox={'fc':'w', 'alpha':0.5, 'ec':'None'},
-                  )
+        axes[1].text(0.03,0.97, label,
+                      ha='left', va='top',
+                      transform=axes[1].transAxes,
+                      fontsize=8, 
+                      bbox={'fc':'w', 'alpha':0.5, 'ec':'None'},
+                      )
         
     if xlim is not None:
         xvi = np.interp(xlim, sp['wave'], np.arange(len(sp)))


### PR DESCRIPTION
Now just drizzle the 2D spectra straight from the calibrated cutouts without having to go through `extract_spectrum`.  Main code is in `msaexp.drizzle`.