### PR TITLE
Generalize initialize slit object

### DIFF
--- a/msaexp/utils.py
+++ b/msaexp/utils.py
@@ -265,6 +265,7 @@ def update_slit_dq_mask(slit, mask_padded=False, bar_threshold=-1, verbose=True)
         file if the filename was provided
     
     """
+    from gwcs import wcstools
     from jwst.datamodels import SlitModel
     
     if isinstance(slit, str):


### PR DESCRIPTION
There seems to occasionally be a memory leak or something that causes different numbers of pixels to be masked in the drizzled outlier rejection.  This update standardizes a function for initializing the `SlitModel` objects to include the updates to the DQ arrays and metadata keywords. 

Other minor updates:
- minor formatting issues
- option to smooth the 2D spectrum when making the figures