### PR TITLE
Functions for better pixel-integrated Gaussian templates

### DIFF
--- a/msaexp/resample.py
+++ b/msaexp/resample.py
@@ -54,3 +54,90 @@ def resample_template(spec_wobs, spec_R_fwhm, templ_wobs, templ_flux, velocity_s
         fres[i] = np.trapz(templ_flux[sl]*g, lsl)
         
     return fres
+
+
+def sample_gaussian_line(spec_wobs, spec_R_fwhm, line_um, line_flux=1., velocity_sigma=100):
+    """
+    Sample a Gaussian emission line on the spectrum wavelength grid accounting
+    for pixel integration
+    
+    Parameters
+    ----------
+    spec_wobs : array-like
+        Spectrum wavelengths
+    
+    spec_R_fwhm : array-like
+        Spectral resolution `wave/d(wave)`, FWHM
+    
+    line_um : float
+        Emission line central wavelength, in microns
+    
+    line_flux : float
+        Normalization of the line
+    
+    velocity_sigma : float
+        Kinematic velocity width, km/s
+    
+    Returns
+    -------
+    resamp : array-like
+        Emission line "template" resampled at the `spec_wobs` wavelengths
+    
+    """
+    Rw = np.interp(line_um, spec_wobs, spec_R_fwhm)
+    dw = np.sqrt((velocity_sigma/3.e5)**2 + (1./2.35/Rw)**2)*line_um
+    
+    resamp = pixel_integrated_gaussian(spec_wobs, line_um, dw,
+                                       normalization=line_flux)
+        
+    return resamp
+
+
+def pixel_integrated_gaussian(x, mu, sigma, normalization=1.):
+    """
+    Low level function for a pixel-integrated gaussian
+    
+    Parameters
+    ----------
+    x : array-like
+        Sample centers
+    
+    mu : float
+        Gaussian center
+    
+    sigma : float
+        Gaussian width
+    
+    normalization : float
+        Scaling
+    
+    Returns
+    -------
+    samp : array-like
+        Pixel-integrated Gaussian
+    
+    """
+    from math import erf
+    
+    N = len(x)
+    samp = np.zeros_like(x)
+    s2dw = np.sqrt(2)*sigma
+    
+    # i = 0
+    i = 0
+    x0 = x[i] - mu
+    dx = x[i+1] - x[i]
+    
+    left = erf((x0 - dx/2)/s2dw)
+    right = erf((x0 + dx/2)/s2dw)
+    samp[i] = (right - left)/2/dx*normalization
+    
+    for i in range(1, N):
+        x0 = x[i] - mu
+        dx = x[i] - x[i-1]
+        
+        left = erf((x0 - dx/2)/s2dw)
+        right = erf((x0 + dx/2)/s2dw)
+        samp[i] = (right - left)/2/dx*normalization
+    
+    return samp

--- a/msaexp/tests/test_spectra.py
+++ b/msaexp/tests/test_spectra.py
@@ -18,7 +18,8 @@ eazy_templates = None
 
 def data_path():
     return os.path.join(os.path.dirname(__file__), 'data')
-    
+
+
 def test_init():
     """
     Initialize pipeline object with previously-extracted slitlets
@@ -223,4 +224,30 @@ def test_fit_redshift():
         #                    [75.95547, 3.7042],
         #                    rtol=0.5))
 
+
+def test_sampler_object():
+    """
+    Test the spectrum.SpectrumSampler methods
+    """
+    
+    os.chdir(data_path())
+    
+    spec = spectrum.SpectrumSampler('ceers-prism.1345_933.v0.spec.fits')
+    
+    assert(spec.valid.sum() == 364)
+    
+    # emission line
+    z = 4.2341
+    line_um = 3727.*(1+z)/1.e4
+    
+    
+    for s in [1, 1.3, 1.8, 2.]:
+        for v in [50, 100, 300, 500, 1000]:
+            kws = dict(scale_disp=s, velocity_sigma=v)
+
+            gau = spec.emission_line(line_um, line_flux=1, **kws)
+            assert(np.allclose(np.trapz(gau, spec.spec_wobs), 1., rtol=1.e-3))
+
+            gau2 = spec.fast_emission_line(line_um, line_flux=1, **kws)
+            assert(np.allclose(np.trapz(gau2, spec.spec_wobs), 1., rtol=1.e-3))
 


### PR DESCRIPTION
Implement more robust, fast function for making emission-line templates accounting for the pixel sampling of the spectrum.  The differences w.r.t. the current implementation are subtle but become increasingly important for under-sampled spectra.