### PR TITLE
Make `SpectrumSampler.redo_1d_extraction` method

### DIFF
--- a/docs/msaexp/api.rst
+++ b/docs/msaexp/api.rst
@@ -15,4 +15,9 @@ Additional API
 .. automodapi:: msaexp.msa
     :no-inheritance-diagram:
 
+.. automodapi:: msaexp.resample
+    :no-inheritance-diagram:
+
+.. automodapi:: msaexp.resample_numba
+    :no-inheritance-diagram:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ sphinx_astropy
 pyyaml
 docutils<0.18
 sregion
+numba

--- a/msaexp/resample.py
+++ b/msaexp/resample.py
@@ -2,6 +2,9 @@ import numpy as np
 import os
 from grizli import utils
 
+__all__ = ["resample_template", "sample_gaussian_line",
+           "pixel_integrated_gaussian"]
+           
 def resample_template(spec_wobs, spec_R_fwhm, templ_wobs, templ_flux, velocity_sigma=100, nsig=5):
     """
     Resample a high resolution template/model on the wavelength grid of a

--- a/msaexp/resample_numba.py
+++ b/msaexp/resample_numba.py
@@ -4,6 +4,9 @@ from grizli import utils
 from numba import jit, njit
 from math import erf
 
+__all__ = ["resample_template_numba", "sample_gaussian_line_numba",
+           "pixel_integrated_gaussian_numba"]
+
 @jit(nopython=True, fastmath=True, error_model='numpy')
 def resample_template_numba(spec_wobs, spec_R_fwhm, templ_wobs, templ_flux, velocity_sigma=100, nsig=5, fill_value=0.):
     """

--- a/msaexp/spectrum.py
+++ b/msaexp/spectrum.py
@@ -300,7 +300,8 @@ class SpectrumSampler(object):
     
     def emission_line(self, line_um, line_flux=1, scale_disp=1.0, velocity_sigma=100., nsig=4):
         """
-        Make an emission line template - **deprecated in favor of fast_emission_line**
+        Make an emission line template - *deprecated in favor of*
+        `~msaexp.spectrum.SpectrumSampler.fast_emission_line`
         
         Parameters
         ----------
@@ -421,6 +422,47 @@ class SpectrumSampler(object):
         output : `~msaexp.spectrum.SpectrumSampler`
             A new `~msaexp.spectrum.SpectrumSampler` object
         
+        Examples
+        --------
+        
+        .. plot::
+            :include-source:
+        
+            # Compare 1D extractions
+            from msaexp import spectrum
+            import matplotlib.pyplot as plt
+
+            sp = spectrum.SpectrumSampler('https://s3.amazonaws.com/msaexp-nirspec/extractions/ceers-ddt-v1/ceers-ddt-v1_prism-clear_2750_1598.spec.fits')
+
+            fig, axes = plt.subplots(2,1,figsize=(8,5), sharex=True, sharey=True)
+
+            # Boxcar extraction, center pixel +/- 2 pix
+            ax = axes[0]
+            new = sp.redo_1d_extraction(ap_radius=2, bkg_offset=-6)
+
+            ax.plot(sp['wave'], sp['flux'], alpha=0.5, label='Original optimal extraction')
+            ax.plot(new['wave'], new['aper_flux'], alpha=0.5, label='Boxcar, y = 23 ± 2')
+
+            ax.grid()
+            ax.legend()
+
+            # Extractions above and below the center
+            ax = axes[1]
+            low = sp.redo_1d_extraction(ap_center=21, ap_radius=1)
+            hi = sp.redo_1d_extraction(ap_center=25, ap_radius=1)
+
+            ax.plot(low['wave'], low['aper_flux']*1.5, alpha=0.5, label='Below, y = 21 ± 1', color='b')
+            ax.plot(hi['wave'], hi['aper_flux']*3, alpha=0.5, label='Above, y = 25 ± 1', color='r')
+
+            ax.set_xlim(0.9, 5.3)
+            ax.grid()
+            ax.legend()
+
+            ax.set_xlabel(r'$\lambda$')
+            for ax in axes:
+                ax.set_ylabel(r'$\mu\mathrm{Jy}$')
+
+            fig.tight_layout(pad=1)
         """
         
         if isinstance(self.spec_input, pyfits.HDUList):

--- a/msaexp/tests/test_drizzle.py
+++ b/msaexp/tests/test_drizzle.py
@@ -2,8 +2,13 @@ import os
 import copy
 
 import numpy as np
+import matplotlib.pyplot as plt
 
-from .. import utils
+from .. import utils, pipeline
+from .. import drizzle as msadrizzle
+
+pipe = None
+TARGETS = ['1345_933']
 
 def data_path():
     return os.path.join(os.path.dirname(__file__), 'data')
@@ -11,11 +16,7 @@ def data_path():
 def test_combine():
     """
     Test drizzle combination from slitlet
-    """
-    import matplotlib.pyplot as plt
-    
-    from .. import drizzle as msadrizzle
-    
+    """    
     os.chdir(data_path())
     
     drizzle_kws = dict(center_on_source=False,  # Center output source as defined in MSA file.
@@ -95,4 +96,172 @@ def test_combine():
     fig.savefig(f'{outroot}-{grating}_{target}.flam.png')
     
     plt.close('all')
+
+#############
+# A-B background subtractions
+
+def test_init_pipeline():
+    """
+    Initialize pipeline object with previously-extracted slitlets
+    """
+    import glob
+    global pipe
+
+    os.chdir(data_path())
+
+    mode = 'jw01345062001_03101_00001_nrs2'
+
+    files = [f'jw01345062001_03101_0000{i}_nrs2_rate.fits'
+             for i in [1,2,3]]
+
+    pipe = pipeline.NirspecPipeline(mode=mode, files=files)
+
+    pipe.full_pipeline(run_extractions=False,
+                       initialize_bkg=True,
+                       targets=TARGETS,
+                       load_saved='phot')
+
+
+def test_extract_spectra_pipeline():
+    """
+    Extract single spectra
+    """
+
+    os.chdir(data_path())
+
+    fit_profile = {'min_delta':20}
+    yoffset = 0.01
+
+    key = TARGETS[0]
+
+    _data = pipe.extract_spectrum(key, skip=[],
+                              yoffset=yoffset,
+                              prof_sigma=0.7,
+                              trace_sign=-1,
+                              fit_profile_params=fit_profile,
+                              )
+
+    plt.close('all')
+
+    slitlet, sep1d, opt1d, fig = _data
+
+
+def test_drizzle_combine_slits():
+    """
+    Drizzle combination
+    """
+
+    os.chdir(data_path())
+
+    DRIZZLE_PARAMS = dict(output=None,
+                          single=True,
+                          blendheaders=True,
+                          pixfrac=0.6,
+                          kernel='square',
+                          fillval=0,
+                          wht_type='ivm',
+                          good_bits=0,
+                          pscale_ratio=1.0,
+                          pscale=None,
+                          verbose=False)
+
+    key = TARGETS[0]
+
+    slits = []
+    slits += pipe.get_background_slits(key, step='bkg', check_background=True)
+
+    for slit in slits:
+        slit.dq = slit.dq & (1+1024)
+
+    print(f'{key}  N= {len(slits)}  slits')
+
+    drizzle_kws = dict(center_on_source=False,  # Center output source as defined in MSA file.
+                       fix_slope=None,          # Cross-dispersion scale dslit/dpix
+                       force_nypix=31,         # Y size of output array
+                       bkg_offset=-6,           # Number of pixels to roll for background sub
+                       bkg_parity=[-1,1],      # Roll directions for background, i.e., -1 rolls 
+                       log_step=False,         # Log wavelength steps
+                       outlier_threshold=10,   # Outlier rejection threshold
+                       err_threshold=1000,     # Reject pixels in a slit where err > err_threshold*median(err)
+                       show_drizzled=True,     # Figures
+                       show_slits=True,
+                       imshow_kws=dict(vmin=-0.05, vmax=0.4, aspect='auto', cmap='cubehelix_r'),
+                       sn_threshold=-np.inf,   # Reject pixels where S/N < sn_threshold.  
+                       bar_threshold=0.0,      # Mask pixels where barshadow array less than this value
+                      )
     
+    DRIZZLE_PARAMS = copy.deepcopy(msadrizzle.DRIZZLE_PARAMS)
+    DRIZZLE_PARAMS['kernel'] = 'square'
+    DRIZZLE_PARAMS['pixfrac'] = 1.0
+    
+    target = '933'
+    
+    drizzle_kws['fix_slope'] = 0.2
+    drizzle_kws['center_on_source'] = True
+    outroot = 'test-driz-center-bkg'
+    
+    _ = msadrizzle.drizzle_slitlets(target, files=slits,
+                                    output=outroot,
+                                    # files=slit_files[:],
+                                    **drizzle_kws,
+                                    )
+    
+    figs, hdu_data, wavedata, all_slits, drz_data = _
+    
+    # 1D extraction
+    extract_kws = dict(prf_sigma=1.2, fix_sigma=False,
+                       prf_center=None, fix_center=False,
+                       center_limit=3,
+                       verbose=True,
+                       profile_slice=None
+                      )
+    
+    grating = 'prism-clear'
+    hdul = hdu_data[grating]
+
+    outhdu = msadrizzle.extract_from_hdul(hdul, **extract_kws)
+    
+    file = f'{outroot}_{target}.spec.fits'
+
+    outhdu.writeto(file, overwrite=True)
+
+    # Make figures
+    fig = utils.drizzled_hdu_figure(outhdu, unit='fnu')
+    fig.savefig(f'{outroot}-{grating}_{target}.fnu.png')
+
+    fig = utils.drizzled_hdu_figure(outhdu, unit='flam')
+    fig.savefig(f'{outroot}-{grating}_{target}.flam.png')
+    
+    plt.close('all')
+    
+    # #########
+    # hdul = utils.drizzle_2d_pipeline(slits,
+    #                                  drizzle_params=DRIZZLE_PARAMS,
+    #                                  fit_prf=True,
+    #                                  outlier_threshold=30000,
+    #                                  prf_center=-0.0,
+    #                                  prf_sigma=1.0,
+    #                                  fix_sigma=True,
+    #                                  center_limit=6.0,
+    #                                  standard_waves=False,
+    #                                  # profile_slice=slice(100,150),
+    #                                  )
+    #
+    # z = 4.2341
+    # _fig = utils.drizzled_hdu_figure(hdul,
+    #                                  z=z,
+    #                                  xlim=None,
+    #                                  unit='fnu')
+    # ax = _fig.axes[2]
+    # xl = ax.get_xlim()
+    #
+    # ax.text(0.02, 0.82, key, ha='left', va='bottom', transform=ax.transAxes)
+    #
+    # plt.close('all')
+    # froot = 'ceers-prism'
+    # hdul.writeto(f'{froot}.{key}.v0.spec.fits', overwrite=True)
+    #
+    # # Figure
+    # with pyfits.open(f'{froot}.{key}.v0.spec.fits') as outhdu:
+    #     fig = utils.drizzled_hdu_figure(outhdu, unit='fnu')
+    #     fig.savefig(f'{froot}.{key}.v0.spec.fnu.png')

--- a/msaexp/tests/test_spectra.py
+++ b/msaexp/tests/test_spectra.py
@@ -142,7 +142,7 @@ def test_sampler_object():
 
 def sampler_checks(spec):
     
-    assert(spec.valid.sum() == 327)
+    assert(np.allclose(spec.valid.sum(), 327, atol=5))
     
     # emission line
     z = 4.2341

--- a/msaexp/tests/test_spectra.py
+++ b/msaexp/tests/test_spectra.py
@@ -9,123 +9,16 @@ plt.ioff()
 
 import astropy.io.fits as pyfits
 
-from .. import utils, spectrum, pipeline
+from .. import utils, spectrum
 
-pipe = None
-TARGETS = ['1345_933']
 eazy_templates = None
 
+# SPECTRUM_FILE = f'ceers-prism.1345_933.v0.spec.fits'
+SPECTRUM_FILE = 'test-driz-center-bkg_933.spec.fits'
+# SPECTRUM_FILE = 'test-driz-center_933.spec.fits'
 
 def data_path():
     return os.path.join(os.path.dirname(__file__), 'data')
-
-
-def test_init():
-    """
-    Initialize pipeline object with previously-extracted slitlets
-    """
-    import glob
-    global pipe
-    
-    os.chdir(data_path())
-    
-    mode = 'jw01345062001_03101_00001_nrs2'
-    
-    files = [f'jw01345062001_03101_0000{i}_nrs2_rate.fits'
-             for i in [1,2,3]]
-    
-    pipe = pipeline.NirspecPipeline(mode=mode, files=files)
-    
-    pipe.full_pipeline(run_extractions=False,
-                       initialize_bkg=True,
-                       targets=TARGETS,
-                       load_saved='phot')
-
-
-def test_extract_spectra():
-    """
-    Extract single spectra
-    """
-    
-    os.chdir(data_path())
-    
-    fit_profile = {'min_delta':20}
-    yoffset = 0.01
-    
-    key = TARGETS[0]
-    
-    _data = pipe.extract_spectrum(key, skip=[],
-                              yoffset=yoffset,
-                              prof_sigma=0.7,
-                              trace_sign=-1, 
-                              fit_profile_params=fit_profile,
-                              )
-    
-    plt.close('all')
-    
-    slitlet, sep1d, opt1d, fig = _data
-
-
-def test_drizzle_combine():
-    """
-    Drizzle combination
-    """
-    
-    os.chdir(data_path())
-    
-    DRIZZLE_PARAMS = dict(output=None,
-                          single=True,
-                          blendheaders=True,
-                          pixfrac=0.6,
-                          kernel='square',
-                          fillval=0,
-                          wht_type='ivm',
-                          good_bits=0,
-                          pscale_ratio=1.0,
-                          pscale=None,
-                          verbose=False)
-    
-    key = TARGETS[0]
-    
-    slits = []
-    slits += pipe.get_background_slits(key, step='bkg', check_background=True)
-
-    for slit in slits:
-        slit.dq = slit.dq & (1+1024)
-    
-    print(f'{key}  N= {len(slits)}  slits')
-
-    hdul = utils.drizzle_2d_pipeline(slits, 
-                                     drizzle_params=DRIZZLE_PARAMS,
-                                     fit_prf=True,
-                                     outlier_threshold=30000,
-                                     prf_center=-0.0,
-                                     prf_sigma=1.0,
-                                     fix_sigma=True,
-                                     center_limit=6.0, 
-                                     standard_waves=False,
-                                     # profile_slice=slice(100,150),
-                                     )
-
-    z = 4.2341
-    _fig = utils.drizzled_hdu_figure(hdul,
-                                     z=z,
-                                     xlim=None,
-                                     unit='fnu')
-    ax = _fig.axes[2]
-    xl = ax.get_xlim()
-
-    ax.text(0.02, 0.82, key, ha='left', va='bottom', transform=ax.transAxes)
-    
-    plt.close('all')
-    froot = 'ceers-prism'
-    hdul.writeto(f'{froot}.{key}.v0.spec.fits', overwrite=True)
-    
-    # Figure
-    with pyfits.open(f'{froot}.{key}.v0.spec.fits') as outhdu:
-        fig = utils.drizzled_hdu_figure(outhdu, unit='fnu')
-        fig.savefig(f'{froot}.{key}.v0.spec.fnu.png')
-
 
 def test_load_templates():
     
@@ -171,11 +64,11 @@ def test_fit_redshift():
     z=4.2341
     z0 = [4.1, 4.4]
     
-    fig, spec, zfit = spectrum.plot_spectrum(f'ceers-prism.1345_933.v0.spec.fits',
+    fig, spec, zfit = spectrum.plot_spectrum(SPECTRUM_FILE,
                                              z=z,
                                              **kws)
     
-    fig.savefig('ceers-prism.1345_933.v0.spec.spl.png')
+    fig.savefig(SPECTRUM_FILE.replace('spec.fits', 'spec.spl.png'))
     
     assert('z' in zfit)
     
@@ -185,11 +78,14 @@ def test_fit_redshift():
     if 'line OIII' in zfit['coeffs']:
         assert(np.allclose(zfit['coeffs']['line OIII'],
               [2386.17, 35.93], rtol=0.5))
-    
+    elif 'line OIII-5007' in zfit['coeffs']:
+        assert(np.allclose(zfit['coeffs']['line OIII-5007'],
+              [1753.03, 35.952727162], rtol=0.5))
+        
     if eazy_templates is not None:
         kws['eazy_templates'] = eazy_templates
         kws['use_full_dispersion'] = False
-        fig, spec, zfit = spectrum.fit_redshift(f'ceers-prism.1345_933.v0.spec.fits',
+        fig, spec, zfit = spectrum.fit_redshift(SPECTRUM_FILE,
                               z0=z0,
                               is_prism=True,
                               **kws)
@@ -232,21 +128,32 @@ def test_sampler_object():
     
     os.chdir(data_path())
     
-    spec = spectrum.SpectrumSampler('ceers-prism.1345_933.v0.spec.fits')
+    spec = spectrum.SpectrumSampler(SPECTRUM_FILE)
+    sampler_checks(spec)
     
-    assert(spec.valid.sum() == 364)
+    new = spec.redo_1d_extraction()
+    sampler_checks(new)
+    
+    # Initialized from HDUList
+    with pyfits.open(SPECTRUM_FILE) as hdul:
+        spec = spectrum.SpectrumSampler(hdul)
+        sampler_checks(spec)
+
+
+def sampler_checks(spec):
+    
+    assert(spec.valid.sum() == 327)
     
     # emission line
     z = 4.2341
     line_um = 3727.*(1+z)/1.e4
-    
     
     for s in [1, 1.3, 1.8, 2.]:
         for v in [50, 100, 300, 500, 1000]:
             kws = dict(scale_disp=s, velocity_sigma=v)
 
             gau = spec.emission_line(line_um, line_flux=1, **kws)
-            assert(np.allclose(np.trapz(gau, spec.spec_wobs), 1., rtol=1.e-3))
+            assert(np.allclose(np.trapz(gau, spec.spec_wobs), 1., rtol=5.e-2))
 
             gau2 = spec.fast_emission_line(line_um, line_flux=1, **kws)
             assert(np.allclose(np.trapz(gau2, spec.spec_wobs), 1., rtol=1.e-3))

--- a/msaexp/utils.py
+++ b/msaexp/utils.py
@@ -2270,14 +2270,15 @@ def make_nirspec_gaussian_profile(waves, sigma=0.5, ycenter=0., ny=31, weight=1,
     prf = np.diff(cdf, axis=0)
     
     if bkg_offset is not None:
-        bkgn = prf*0.
-        bkgd = bkgn*0
+        if bkg_offset > 0:
+            bkgn = prf*0.
+            bkgd = bkgn*0
         
-        for p in bkg_parity:
-            bkgn += np.roll(prf*weight, p*bkg_offset, axis=0)
-            bkgd += np.roll(weight, p*bkg_offset, axis=0)
+            for p in bkg_parity:
+                bkgn += np.roll(prf*weight, p*bkg_offset, axis=0)
+                bkgd += np.roll(weight, p*bkg_offset, axis=0)
             
-        prf -= bkgn/bkgd
+            prf -= bkgn/bkgd
         
     return prf
 


### PR DESCRIPTION
- Implement a method `msaexp.spectrum.SpectrumSampler.redo_1d_extraction` to extract a new 1D spectrum with new fitting parameters
- Update functions and methods to take `astropy.io.fits.HDUList` objects as input, not just string filenames
- Remove deprecated `utils.drizzle_2d_pipeline` from tests
- Add test for drizzling slits with A-B background removed in slit space