### PR TITLE
Save function arguments of `slit_combine.extract_spectra` and `spectrum.fit_redshift` to YAML files 

### DIFF
--- a/msaexp/drizzle.py
+++ b/msaexp/drizzle.py
@@ -641,8 +641,11 @@ def drizzle_slitlets(id, wildcard='*phot', files=None, output=None, verbose=True
         h['BUNIT'] = 'micron'
         hdul.append(pyfits.ImageHDU(data=waves, header=h))
         
+        # output_key = f'{output}-{id}-{gr}'
+        output_key = f'{output}_{gr}_{id}' # match spec.fits
+        
         if output is not None:
-            hdul.writeto(f'{output}-{id}-{gr}.d2d.fits', overwrite=True,
+            hdul.writeto(f'{output_key}.d2d.fits', overwrite=True,
                          output_verify='fix')
         
         if imshow_kws['vmax'] is None:
@@ -658,7 +661,7 @@ def drizzle_slitlets(id, wildcard='*phot', files=None, output=None, verbose=True
         if (show_drizzled):
             dfig = show_drizzled_product(hdul, imshow_kws=imshow_kws)
             if output is not None:
-                dfig.savefig(f'{output}-{id}-{gr}.d2d.png')
+                dfig.savefig(f'{output_key}.d2d.png')
         else:
             dfig = None
 
@@ -667,7 +670,7 @@ def drizzle_slitlets(id, wildcard='*phot', files=None, output=None, verbose=True
                                        imshow_kws=imshow_kws,
                                        with_background=(show_slits > 1))
             if output is not None:
-                sfig.savefig(f'{output}-{id}-{gr}.slit2d.png')
+                sfig.savefig(f'{output_key}.slit2d.png')
         else:
             sfig = None
         

--- a/msaexp/slit_combine.py
+++ b/msaexp/slit_combine.py
@@ -1,5 +1,9 @@
 import os
 import glob
+import inspect
+import time
+
+import yaml
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -2017,7 +2021,7 @@ def get_spectrum_path_loss(spec):
     return 1./path_loss
 
 
-def extract_spectra(target='1208_5110240', root='nirspec', path_to_files='./', files=None, do_gratings=['PRISM','G395H','G395M','G235M','G140M'], join=[0,3,5], split_uncover=True, stuck_min_sn=0.0, pad_border=2, sort_by_sn=False, position_key='y_index', mask_cross_dispersion=None, cross_dispersion_mask_type='trace', trace_from_yoffset=False, reference_exposure='auto', trace_niter=4, offset_degree=0, degree_kwargs={}, recenter_all=False, nod_offset=None, initial_sigma=7, fit_type=1, initial_theta=None, fix_params=False, input_fix_sigma=None, fit_params_kwargs=None, diffs=True, undo_pathloss=True, undo_barshadow=False, drizzle_kws=DRIZZLE_KWS, get_xobj=False, trace_with_xpos=False, trace_with_ypos='auto', get_background=False, make_2d_plots=True):
+def extract_spectra(target='1208_5110240', root='nirspec', path_to_files='./', files=None, do_gratings=['PRISM','G395H','G395M','G235M','G140M'], join=[0,3,5], split_uncover=True, stuck_min_sn=0.0, pad_border=2, sort_by_sn=False, position_key='y_index', mask_cross_dispersion=None, cross_dispersion_mask_type='trace', trace_from_yoffset=False, reference_exposure='auto', trace_niter=4, offset_degree=0, degree_kwargs={}, recenter_all=False, nod_offset=None, initial_sigma=7, fit_type=1, initial_theta=None, fix_params=False, input_fix_sigma=None, fit_params_kwargs=None, diffs=True, undo_pathloss=True, undo_barshadow=False, drizzle_kws=DRIZZLE_KWS, get_xobj=False, trace_with_xpos=False, trace_with_ypos='auto', get_background=False, make_2d_plots=True, **kwargs):
     """
     Spectral combination workflow
     
@@ -2078,9 +2082,17 @@ def extract_spectra(target='1208_5110240', root='nirspec', path_to_files='./', f
     
     """
     global CENTER_WIDTH, CENTER_PRIOR, SIGMA_PRIOR
+    frame = inspect.currentframe()
     
+    # Log function arguments
     utils.LOGFILE = f'{root}_{target}.extract.log'
-    
+    args = utils.log_function_arguments(utils.LOGFILE, frame,
+                                        'slit_combine.extract_spectra')
+    if isinstance(args, dict):
+        with open(f'{root}_{target}.extract.yml', 'w') as fp:
+            fp.write(f'# {time.ctime()}\n# {os.getcwd()}\n')
+            yaml.dump(args, stream=fp, Dumper=yaml.Dumper)
+        
     if files is None:
         files = glob.glob(os.path.join(path_to_files, f'*phot*{target}.fits'))
         

--- a/msaexp/spectrum.py
+++ b/msaexp/spectrum.py
@@ -819,7 +819,10 @@ def fit_redshift(file='jw02767005001-02-clear-prism-nrs2-2767_11027.spec.fits', 
             fp.write(f'# {time.ctime()}\n# {os.getcwd()}\n')
             if eazy_templates is not None:
                 for i, t in enumerate(eazy_templates):
-                    fp.write(f'# eazy_templates[{i}] = \"{t.__str__()}\"\n')
+                    msg = f'# eazy_templates[{i}] = \"{t.__str__()}\"'
+                    utils.log_comment(utils.LOGFILE, msg, verbose=False)
+                    fp.write(msg+'\n')
+            
             yaml.dump(args, stream=fp, Dumper=yaml.Dumper)
     
     #is_prism |= ('clear' in file)

--- a/msaexp/spectrum.py
+++ b/msaexp/spectrum.py
@@ -5,6 +5,13 @@ Fits, etc. to extracted spectra
 import os
 import time
 import warnings
+import inspect
+import yaml
+def float_representer(dumper, value):
+    text = '{0:.6f}'.format(value)
+    return dumper.represent_scalar(u'tag:yaml.org,2002:float', text)
+
+yaml.add_representer(float, float_representer)
 
 import numpy as np
 
@@ -791,22 +798,34 @@ def fit_redshift(file='jw02767005001-02-clear-prism-nrs2-2767_11027.spec.fits', 
         Fit metadata
     
     """
-    import yaml
-    def float_representer(dumper, value):
-        text = '{0:.6f}'.format(value)
-        return dumper.represent_scalar(u'tag:yaml.org,2002:float', text)
-    
-    yaml.add_representer(float, float_representer)
-    
-    #is_prism |= ('clear' in file)
-    spec = read_spectrum(file, sys_err=sys_err, **kwargs)
-    is_prism |= spec.grating in ['prism']
+    frame = inspect.currentframe()
     
     if 'spec.fits' in file:
         froot = file.split('.spec.fits')[0]
     else:
         froot = file.split('.fits')[0]
     
+    # Log function arguments
+    utils.LOGFILE = f'{froot}.zfit.log'
+    if os.path.exists(utils.LOGFILE):
+        os.remove(utils.LOGFILE)
+    
+    # Log arguments
+    args = utils.log_function_arguments(utils.LOGFILE, frame,
+                                        'spectrum.fit_redshift',
+                                        ignore=['eazy_templates'])
+    if isinstance(args, dict):
+        with open(f'{froot}.zfit.call.yml', 'w') as fp:
+            fp.write(f'# {time.ctime()}\n# {os.getcwd()}\n')
+            if eazy_templates is not None:
+                for i, t in enumerate(eazy_templates):
+                    fp.write(f'# eazy_templates[{i}] = \"{t.__str__()}\"\n')
+            yaml.dump(args, stream=fp, Dumper=yaml.Dumper)
+    
+    #is_prism |= ('clear' in file)
+    spec = read_spectrum(file, sys_err=sys_err, **kwargs)
+    is_prism |= spec.grating in ['prism']
+        
     if zstep is None:
         if (is_prism):
             step0 = 0.002
@@ -1689,10 +1708,10 @@ def calc_uncertainty_scale(file=None, data=None, order=0, initial_mask=(0.2, 5),
             _resid = (spec['flux'] - _model)[ok] / _full_err[ok]
             chi2 = np.log(utils.nmad(_resid))**2
         
-        if verbose > 1:
-            cstr = ' '.join([f'{ci:6.2f}' for ci in c])
-            print(f"{cstr}: {chi2:.6e}")
-    
+        cstr = ' '.join([f'{ci:6.2f}' for ci in c])
+        msg = f"{cstr}: {chi2:.6e}"
+        utils.log_comment(utils.LOGFILE, msg, verbose=(verbose > 1))
+
         return chi2
 
     if fit_sys_err:
@@ -2064,11 +2083,11 @@ def plot_spectrum(inp='jw02767005001-02-clear-prism-nrs2-2767_11027.spec.fits', 
         N = len(templates)
         covar = np.eye(N, N)
     
-    print(f'\n# line flux err\n# flux x 10^-20 erg/s/cm2')
+    msg = f'\n# line flux err\n# flux x 10^-20 erg/s/cm2\n'
     if label is not None:
-        print(f'# {label}')
+        msg += f'# {label}\n'
     
-    print(f'# z = {z:.5f}\n# {time.ctime()}')
+    msg += f'# z = {z:.5f}\n# {time.ctime()}\n'
     
     cdict = {}
     eqwidth = {}
@@ -2093,9 +2112,10 @@ def plot_spectrum(inp='jw02767005001-02-clear-prism-nrs2-2767_11027.spec.fits', 
             
             eqwidth[t] = [float(eqwi)]
             
-            print(f'{t:>20}   {coeffs[i]:8.1f} ± {covard[i]:8.1f} (EW={eqwi:9.1f})')
-            
-            
+            msg += f'{t:>20}   {coeffs[i]:8.1f} ± {covard[i]:8.1f} (EW={eqwi:9.1f})\n'
+    
+    utils.log_comment(utils.LOGFILE, msg, verbose=True)
+    
     if 'srcra' not in spec.meta:
         spec.meta['srcra'] = 0.0
         spec.meta['srcdec'] = 0.0


### PR DESCRIPTION
Save keyword arguments to big wrapper functions to text log and YAML files for more flexible reproducibility.

Writing the YAML files requires `grizli >= grizli-1.11.3`.