### PR TITLE
Trace fit: avoid over masking

### DIFF
--- a/msaexp/slit_combine.py
+++ b/msaexp/slit_combine.py
@@ -446,9 +446,13 @@ def objfun_prof_trace(
         else:
             pneg = np.zeros_like(ppos)
     else:
-        ppos = np.nansum(ppos, axis=0) / np.nansum(mask[ipos, :], axis=0)
+        ppos = np.nansum(ppos * mask[ipos, :], axis=0) / np.nansum(
+            mask[ipos, :], axis=0
+        )
         if ineg.sum() > 0:
-            pneg = np.nansum(pneg, axis=0) / np.nansum(mask[ineg, :], axis=0)
+            pneg = np.nansum(pneg * mask[ineg, :], axis=0) / np.nansum(
+                mask[ineg, :], axis=0
+            )
         else:
             pneg = np.zeros_like(ppos)
 
@@ -463,7 +467,7 @@ def objfun_prof_trace(
         pdiff *= pdiff > 0
 
     # Remove any masked pixels
-    pmask = mask.sum(axis=0) == mask.shape[0]
+    pmask = mask.sum(axis=0) > 0
 
     snum = np.nansum(
         ((diff - bkg) * pdiff / vdiff * pmask).reshape(sh), axis=0


### PR DESCRIPTION
Change masking to avoid entirely masking of spectra, by only masking pixels that have no coverage in any individual exposure.

Changes:
When creating ppos and pneg profiles, mask the individual exposure pixels. Final composite mask only masks pixels with no corresponding unmasked pixels in any exposure.

The previous code can result in combined spectra that are almost entirely masked, if the individual exposures have large snowball-masked regions at various non-overlapping positions.

As an example, for UNCOVER id_msa=21111:
**Current code** (plot created with temporary code during extract_spectra, within `extract_spectra()` inserted at line 4138):
<img width="901" alt="image" src="https://github.com/gbrammer/msaexp/assets/5341901/8d0320b3-2077-48f3-a53d-b08b073b9cda">
  
**With the proposed changes:**
<img width="904" alt="image" src="https://github.com/gbrammer/msaexp/assets/5341901/535a0265-a6fb-4f46-8a6d-98cd47454dc6">