### PR TITLE
update_slit_metadata tests and non-existing slitled_id case catching

### DIFF
--- a/msaexp/utils.py
+++ b/msaexp/utils.py
@@ -72,8 +72,11 @@ def update_slit_metadata(slit):
 
     if slit.source_type is None:
         slit.source_type = "EXTENDED"
-
-    if not hasattr(slit, "slitlet_id"):
+    
+    #TODO Needs review. When 'slitlet_id' = None or 
+    # deleted, it is by default reset to 0 by the
+    # jwst datamodel. Is this a good solution? (K.V.) 
+    if slit.slitlet_id == 0:
         slit.slitlet_id = 9999
 
 


### PR DESCRIPTION
This is a premature PR on the utils tests, but as I found one branch in code that needs attention I want to send it right away. 

Tests for all 'if' branches of the `update_slit_metadata` added. 

The last `if` branch would never be reached as it is now, since it is only triggered if the `slit.slitlet_id` attribute is not existing. However, the jwst datamodel automatically sets it to 0 when it is non-existing or `None`, as can be seen recreated here:

```python
>>> import jwst.datamodels
>>> slit = jwst.datamodels.open("/home/kostasvaleckas/Documents/DAWN/msaexp/msaexp/tests/data/jw01345062001_03101_00001_nrs2_phot.138.1345_933.fits")
>>> slit.slitlet_id
138
>>> slit.slitlet_id = None
>>> slit.slitlet_id
0
>>> slit.slitlet_id = 138
>>> slit.slitlet_id
138
>>> del slit.slitlet_id
>>> slit.slitlet_id
0
```
I therefore suggest a fix for checking it for value `0` as a proxy for it not being set, but I am not sure whether this is a good fix. 

All tests pass. 