### PR TITLE
Add some more utilities to `SpectrumSampler`

### DIFF
--- a/.github/workflows/python-package-with-numba.yml
+++ b/.github/workflows/python-package-with-numba.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: CI
+name: CI with numba
 
 on:
   push:

--- a/.github/workflows/python-package-with-numba.yml
+++ b/.github/workflows/python-package-with-numba.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-    NUMBA_DISABLE_JIT: 1
+    NUMBA_DISABLE_JIT: 0
 
 jobs:
   build:
@@ -67,7 +67,7 @@ jobs:
         pip install pytest coverage numba
     - name: Run tests with coverage
       run: |
-        coverage run -m pytest msaexp/tests/test_numba.py msaexp/tests/test_spectra.py
+        coverage run -m pytest
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.0.1
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,7 +67,7 @@ jobs:
         pip install pytest coverage numba
     - name: Run tests with coverage
       run: |
-        coverage run -m pytest msaexp/tests/test_numba.py msaexp/tests/test_spectra.py
+        coverage run -m pytest msaexp/tests/test_numba.py
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4.0.1
       with:

--- a/msaexp/resample_numba.py
+++ b/msaexp/resample_numba.py
@@ -147,6 +147,10 @@ def resample_template_numba(
     velocity_sigma=100,
     nsig=5,
     fill_value=0.0,
+    wave_min=0.0,
+    wave_max=1.0e6,
+    left=0.0,
+    right=0.0,
 ):
     """
     Resample a high resolution template/model on the wavelength grid of a
@@ -176,6 +180,15 @@ def resample_template_numba(
     fill_value : float
         Value to fill in the resampled array where no template data is available
 
+    wave_min : float
+        Minimum wavelength to consider
+
+    wave_max : float
+        Maximum wavelength to consider
+
+    left, right : float
+        Fill values when wavelengths less (greater) than wave_min (wave_max)
+
     Returns
     -------
     resamp : array-like
@@ -200,12 +213,18 @@ def resample_template_numba(
     ihi = 1
 
     N = len(spec_wobs)
-    resamp = np.zeros_like(spec_wobs) * fill_value
+    resamp = np.ones_like(spec_wobs) * fill_value
 
     Nt = len(templ_wobs)
 
     for i in range(N):
-        # sl = slice(ilo[i], ihi[i])
+        if spec_wobs[i] < wave_min:
+            resamp[i] = left
+            continue
+        elif spec_wobs[i] > wave_max:
+            resamp[i] = right
+            continue
+
         ilo_i = ilo
         while (templ_wobs[ilo] < spec_wobs[i] - nsig * dw[i]) & (ilo < Nt - 1):
             ilo += 1

--- a/msaexp/spectrum.py
+++ b/msaexp/spectrum.py
@@ -110,7 +110,7 @@ __all__ = [
 
 def resample_bagpipes_model(
     model_galaxy,
-    model_comp,
+    model_comp=None,
     spec_wavs=None,
     R_curve=None,
     nsig=5,
@@ -123,7 +123,9 @@ def resample_bagpipes_model(
     model_galaxy : `bagpipes.models.model_galaxy.model_galaxy`
 
     model_comp : dict
-        Model components dictionary
+        Model components dictionary.  If specified, run
+        ``model_galaxy.update(model_comp)``, otherwise get from
+        ``model_galaxy.model_comp``
 
     spec_wavs : array-like, None
         Spectrum wavelengths, Angstroms. If not specified, try to use
@@ -149,6 +151,11 @@ def resample_bagpipes_model(
 
     """
     from .resample_numba import resample_template_numba
+
+    if model_comp is not None:
+        model_galaxy.update(model_comp)
+
+    model_comp = model_galaxy.model_comp
 
     zplusone = model_comp["redshift"] + 1.0
 
@@ -621,7 +628,7 @@ class SpectrumSampler(object):
         return fig
 
     def resample_bagpipes_model(
-        self, model_galaxy, model_comp, nsig=5, scale_disp=1.3
+        self, model_galaxy, model_comp=None, nsig=5, scale_disp=1.3
     ):
         """
         Resample a `bagpipes` model to the wavelength grid of the spectrum.
@@ -634,7 +641,7 @@ class SpectrumSampler(object):
 
         spectrum = resample_bagpipes_model(
             model_galaxy,
-            model_comp,
+            model_comp=model_comp,
             spec_wavs=self.spec_wobs * 1.0e4,
             R_curve=self.spec["R"] * scale_disp,
             nsig=nsig,

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     cython
     matplotlib
     scipy
+    numba
     tqdm
     astropy
     pysiaf


### PR DESCRIPTION
- (include ``numba`` as a module dependency)
- ``SpectrumSampler.igm_absorption``
```python
     def igm_absorption(self, z, scale_tau=1.0, scale_disp=1.3):
        """
        `Inoue+ (2014) <https://ui.adsabs.harvard.edu/abs/2014MNRAS.442.1805I>`_ IGM
        absorption

        Parameters
        ----------
        z : float
            Redshift

        scale_tau : float
            Factor to scale $\tau_\mathrm{IGM}$

        scale_disp : float
            Dispersion R rescaling

        Returns
        -------
        igm : array-like
            IGM model transmission at observed-frame wavelengths
        """
```
- Make ``model_comp`` an optional input to ``resample_bagpipes_model``
