### PR TITLE
Add method to merge msametfl source_ids

### DIFF
--- a/msaexp/pipeline_extended.py
+++ b/msaexp/pipeline_extended.py
@@ -599,9 +599,10 @@ def run_pipeline(
 
         # Use new reference
         wcs_reference_files["wavelengthrange"] = new_waverange
-        slit_y_range = [wstep.slit_y_low, wstep.slit_y_high]
+        # slit_y_range = [wstep.slit_y_low, wstep.slit_y_high]
         try:
-            with_wcs = load_wcs(dm, wcs_reference_files, slit_y_range)
+            # with_wcs = load_wcs(dm, wcs_reference_files, slit_y_range)
+            with_wcs = wstep.call(dm, override_wavelengthrange=new_waverange)
         except NoDataOnDetectorError:
             msg = f"{file} No open slits found to work on"
             utils.log_comment(utils.LOGFILE, msg, verbose=VERBOSITY)
@@ -613,7 +614,7 @@ def run_pipeline(
         # MSAFlagOpen
         msg = f"{file} MSAFlagOpen"
         utils.log_comment(utils.LOGFILE, msg, verbose=VERBOSITY)
-        with_wcs = MSAFlagOpenStep().process(with_wcs)
+        flag_open = MSAFlagOpenStep().call(with_wcs)
 
     ############
     # Extract2D

--- a/msaexp/pipeline_extended.py
+++ b/msaexp/pipeline_extended.py
@@ -608,6 +608,13 @@ def run_pipeline(
             utils.LOGFILE = ORIG_LOGFILE
             return None
 
+    if with_wcs.meta.exposure.type == "NRS_MSASPEC":
+        ############
+        # MSAFlagOpen
+        msg = f"{file} MSAFlagOpen"
+        utils.log_comment(utils.LOGFILE, msg, verbose=VERBOSITY)
+        with_wcs = MSAFlagOpenStep().process(with_wcs)
+
     ############
     # Extract2D
     msg = f"{file} Extract2D"


### PR DESCRIPTION
The `source_id` numbers attached to a particular `slitlet_id` in a MSA metadata file can be irregular as multiple catalog objects fall in the open shutters during the nod offsetting.  This update adds a method to the `msaexp.msa.MSAMetafile` object to merge the source_ids associated with a particular `slitlet_id`.