### PR TITLE
Fit a polynomial to the tabulated resolution curves

### DIFF
--- a/msaexp/spectrum.py
+++ b/msaexp/spectrum.py
@@ -2696,21 +2696,16 @@ def read_spectrum(
     grating = spec.meta["GRATING"].lower()
     _filter = spec.meta["FILTER"].lower()
 
+    # ToDo: use utils function
     if "R" not in spec.colnames:
-        _data_path = os.path.dirname(__file__)
-        disp = utils.read_catalog(
-            f"{_data_path}/data/jwst_nirspec_{grating}_disp.fits"
+        R_fwhm = msautils.get_default_resolution_curve(
+            grating=grating,
+            wave=spec['wave'],
+            # grating_degree=2 default poly fit for gratings
+            **kwargs
         )
-
-        spec.disp = disp
-
-        spec["R"] = np.interp(
-            spec["wave"],
-            disp["WAVELENGTH"],
-            disp["R"],
-            left=disp["R"][0],
-            right=disp["R"][-1],
-        )
+        spec["R"] = R_fwhm
+        spec["R"].description = "Spectral resolution from tabulated curves"
 
     spec.grating = grating
     spec.filter = _filter

--- a/msaexp/tests/test_utils.py
+++ b/msaexp/tests/test_utils.py
@@ -30,6 +30,58 @@ def test_wavelength_grids():
     grid = utils.get_standard_wavelength_grid("prism", free_prism=False)
 
 
+def test_resolution_curves():
+    """
+    """
+    for gr in utils.GRATING_LIMITS:
+
+        wgrid = utils.get_standard_wavelength_grid(gr)
+
+        for grating in [gr.upper(), gr.lower()]:
+            # calculate grid internally
+            R = utils.get_default_resolution_curve(
+                grating=grating,
+                wave=None,
+                grating_degree=2
+            )
+
+            # With grating fit
+            Rg = utils.get_default_resolution_curve(
+                grating=grating,
+                wave=wgrid,
+                grating_degree=2
+            )
+
+            # Without extrapolation
+            Ri = utils.get_default_resolution_curve(
+                grating=grating,
+                wave=wgrid,
+                grating_degree=None
+            )
+
+            # Only test over first part of the array
+            sl = slice(0, 200)
+            assert np.allclose(R[sl], Rg[sl], rtol=1.e-3)
+            assert np.allclose(R[sl], Ri[sl], rtol=1.e-3)
+    
+    # Test extrapolation from fit
+    grating = 'G235M'
+    wgrid = np.array([
+        2.0, # In nominal range
+        4.0, # Extended
+    ])
+
+    # With polynomial extrapolation
+    for deg in [0, 1, 2, 3]:
+        Rg = utils.get_default_resolution_curve(
+            grating=grating,
+            wave=wgrid,
+            grating_degree=deg
+        )
+        # R(2 x lam) ~ 2 * R(lam)
+        assert np.allclose(Rg[1] / Rg[0], 2.0, rtol=0.05)
+
+
 def test_fwhm():
 
     import numpy as np


### PR DESCRIPTION
The spectral resolution curves in [msaexp/data](https://github.com/gbrammer/msaexp/tree/main/msaexp/data) are taken from the tables provided in the [NIRSpec documentation page](https://jwst-docs.stsci.edu/jwst-near-infrared-spectrograph/nirspec-instrumentation/nirspec-dispersers-and-filters#NIRSpecDispersersandFilters-NIRSpecDispersersNIRSpecdispersers).

This update implements using a polynomial fit to  $f(\lambda) = \lambda / R$ to enable extrapolating the resolution curves of the gratings for wavelengths beyond the original tables.  The function $f(\lambda)$ is nearly linear with $\lambda$ to a few percent across the nominal first-order spectral range of the gratings (see [Jakobsen et al. 2022](https://ui.adsabs.harvard.edu/abs/2022A%26A...661A..80J)).
