### PR TITLE
Remove calls to deprecated np.cast

### DIFF
--- a/msaexp/drizzle.py
+++ b/msaexp/drizzle.py
@@ -1116,10 +1116,9 @@ def make_optimal_extraction(
             else:
                 # Wavelengths interpolated on pixel grid
                 xpix = np.arange(sh[1])
-                xsl = np.cast[int](
-                    np.round(np.interp(profile_slice, waves, xpix))
-                )
+                xsl = np.round(np.interp(profile_slice, waves, xpix)).astype(int)
                 xsl = np.clip(xsl, 0, sh[1])
+
                 print(f"Wavelength slice: {profile_slice} > {xsl} pix")
                 profile_slice = slice(*xsl)
 

--- a/msaexp/resample.py
+++ b/msaexp/resample.py
@@ -72,8 +72,8 @@ def resample_template(
     )
 
     ix = np.arange(templ_wobs.shape[0])
-    ilo = np.cast[int](np.interp(spec_wobs - nsig * dw, templ_wobs, ix))
-    ihi = np.cast[int](np.interp(spec_wobs + nsig * dw, templ_wobs, ix)) + 1
+    ilo = np.array(np.interp(spec_wobs - nsig * dw, templ_wobs, ix)).astype(int)
+    ihi = np.array(np.interp(spec_wobs + nsig * dw, templ_wobs, ix)).astype(int) + 1
 
     N = len(spec_wobs)
     fres = np.ones(N) * fill_value

--- a/msaexp/slit_combine.py
+++ b/msaexp/slit_combine.py
@@ -2742,7 +2742,7 @@ class SlitGroup:
             return None
 
         un = utils.Unique(
-            np.cast[int](np.round(shutter_y[bar_mask])), verbose=False
+            np.round(shutter_y[bar_mask]).astype(int), verbose=False
         )
         sn_shutters = np.zeros(un.N, dtype=float)
         for i, v in enumerate(un.values):

--- a/msaexp/utils.py
+++ b/msaexp/utils.py
@@ -1503,9 +1503,8 @@ def combine_2d_with_rejection(
 
                 _wcs = drizzled_slits[0].meta.wcs
                 _, _, wave0 = _wcs.forward_transform(xpix, ypix)
-                xsl = np.cast[int](
-                    np.round(np.interp(profile_slice, wave0, xpix))
-                )
+                xsl = np.round(np.interp(profile_slice, wave0, xpix)).astype(int)
+
                 xsl = np.clip(xsl, 0, sh[1])
                 print(f"Wavelength slice: {profile_slice} > {xsl} pix")
                 profile_slice = slice(*xsl)


### PR DESCRIPTION
`numpy.cast` was removed in `numpy >= 2.0`.  Update bits that used it to `np.array().astype()`.